### PR TITLE
chore: Fix syntax error

### DIFF
--- a/apps/drec-api/src/pods/invitation/invitation.service.ts
+++ b/apps/drec-api/src/pods/invitation/invitation.service.ts
@@ -137,7 +137,7 @@ export class InvitationService {
       orgName: organization.name,
       organizationType: organization.organizationType,
       //@ts-ignore
-      orgid?: organization.id
+      orgid: organization.id | undefined
       // orgAddress:''
 
     }


### PR DESCRIPTION
Fixes

```
[error] src/pods/invitation/invitation.service.ts: SyntaxError: A property assignment cannot have a question token. (140:12)
[error]   138 |       organizationType: organization.organizationType,
[error]   139 |       //@ts-ignore
[error] > 140 |       orgid?: organization.id
[error]       |            ^
[error]   141 |       // orgAddress:''
[error]   142 |
[error]   143 |     }
```