### PR TITLE
When apiuser get device by developerexternalId query changed to check…

### DIFF
--- a/apps/drec-api/src/pods/device/device.controller.ts
+++ b/apps/drec-api/src/pods/device/device.controller.ts
@@ -404,13 +404,13 @@ export class DeviceController {
   ): Promise<DeviceDTO | null> {
     this.logger.verbose(`With in getByExternalId`);
     let devicedata: Device;
-    if(loginUser.role=== Role.ApiUser) {
-      devicedata = await this.deviceService.findDeviceByDeveloperExternalIByApiUser(
-        id,
-        loginUser.api_user_id,
-      );
-    }
-    else{
+    if (loginUser.role === Role.ApiUser) {
+      devicedata =
+        await this.deviceService.findDeviceByDeveloperExternalIByApiUser(
+          id,
+          loginUser.api_user_id,
+        );
+    } else {
       devicedata = await this.deviceService.findDeviceByDeveloperExternalId(
         id,
         loginUser.organizationId,

--- a/apps/drec-api/src/pods/device/device.controller.ts
+++ b/apps/drec-api/src/pods/device/device.controller.ts
@@ -400,13 +400,22 @@ export class DeviceController {
   })
   async getByExternalId(
     @Param('id') id: string,
-    @UserDecorator() { organizationId }: ILoggedInUser,
+    @UserDecorator() loginUser: ILoggedInUser,
   ): Promise<DeviceDTO | null> {
     this.logger.verbose(`With in getByExternalId`);
-    const devicedata = await this.deviceService.findDeviceByDeveloperExternalId(
-      id,
-      organizationId,
-    );
+    let devicedata: Device;
+    if(loginUser.role=== Role.ApiUser) {
+      devicedata = await this.deviceService.findDeviceByDeveloperExternalIByApiUser(
+        id,
+        loginUser.api_user_id,
+      );
+    }
+    else{
+      devicedata = await this.deviceService.findDeviceByDeveloperExternalId(
+        id,
+        loginUser.organizationId,
+      );
+    }
     devicedata.externalId = devicedata.developerExternalId;
     delete devicedata['developerExternalId'];
     return devicedata;

--- a/apps/drec-api/src/pods/device/device.service.ts
+++ b/apps/drec-api/src/pods/device/device.service.ts
@@ -495,6 +495,29 @@ export class DeviceService {
     );
     return device;
   }
+
+  async findDeviceByDeveloperExternalIByApiUser(
+    meterId: string,
+    api_user_id: string,
+  ): Promise<Device | null> {
+    this.logger.verbose(`With in findDeviceByDeveloperExternalIByApiUser`);
+    const device: Device = await this.repository.findOne({
+      where: {
+        developerExternalId: meterId,
+        api_user_id: api_user_id,
+      },
+    });
+    if (!device) {
+      this.logger.warn(`Returning null`);
+      return null;
+    }
+    device.timezone = await getLocalTimeZoneFromDevice(
+      device.createdAt,
+      device,
+    );
+    return device;
+  }
+
   async findMultipleDevicesBasedExternalId(
     meterIdList: Array<string>,
     organizationId: number,


### PR DESCRIPTION
… by api_user_id instead of orgId as from UI we are not able to pass orgId of apiuser's developer