### PR TITLE
Add `.git-glame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Apply `Prettier` to entire code base
+c3d98ff4ececdd9041aea74d5db2be30dc089283


### PR DESCRIPTION
This repository was reformatted using Prettier here: https://github.com/d-rec/drec-origin/pull/155

But the commit was never added to `.git-glame-ignore-revs`. Adding it here to make our `git blame` useful again.

More context, see for example Black's explanation: https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html#avoiding-ruining-git-blame