### PR TITLE
drec-api-prod.yml - cpu limit has been increased to 500 as per advice from devops team

### DIFF
--- a/apps/drec-api/drec-api-prod.yaml
+++ b/apps/drec-api/drec-api-prod.yaml
@@ -24,7 +24,7 @@ spec:
             - containerPort: 3040
           resources:
             limits:
-              cpu: 100m
+              cpu: 500m
             requests:
               cpu: 50m
 ---


### PR DESCRIPTION
drec-api-prod.yml - cpu limit has been increased to 500 as per advice from devops team