### PR TITLE
feat:Rename class names and types to PascalCase

### DIFF
--- a/apps/drec-api/src/drec.module.spec.ts
+++ b/apps/drec-api/src/drec.module.spec.ts
@@ -20,15 +20,15 @@ import { AggregateMeterRead } from './pods/reads/aggregate_readvalue.entity';
 import { HistoryIntermediate_MeterRead } from './pods/reads/history_intermideate_meterread.entity';
 import { CheckCertificateIssueDateLogForDeviceEntity } from './pods/device/check_certificate_issue_date_log_for_device.entity';
 import { CheckCertificateIssueDateLogForDeviceGroupEntity } from './pods/device-group/check_certificate_issue_date_log_for_device_group.entity';
-import { SdgBenefit } from './pods/sdgbenefit/sdgbenefit.entity';
+import { SDGBenefit } from './pods/sdgbenefit/sdgbenefit.entity';
 import { DeltaFirstRead } from './pods/reads/delta_firstread.entity';
 import { IrecDevicesInformationEntity } from './pods/device/irec_devices_information.entity';
 import { IrecErrorLogInformationEntity } from './pods/device/irec_error_log_information.entity';
 import { UserLoginSessionEntity } from './pods/user/user_login_session.entity';
-import { DeviceLateongoingIssueCertificateEntity } from './pods/device/device_lateongoing_certificate.entity';
+import { DeviceLateOngoingIssueCertificateEntity } from './pods/device/device_lateongoing_certificate.entity';
 import { CertificateLogModule } from './pods/certificate-log/certificate-log.module';
-import { SdgbenefitModule } from './pods/sdgbenefit/sdgbenefit.module';
-import { CountrycodeModule } from './pods/countrycode/countrycode.module';
+import { SDGbenefitModule } from './pods/sdgbenefit/sdgbenefit.module';
+import { CountryCodeModule } from './pods/countrycode/countrycode.module';
 import { PermissionModule } from './pods/permission/permission.module';
 import { AccessControlLayerModuleServiceModule } from './pods/access-control-layer-module-service/access-control-layer-module-service.module';
 import { YieldConfigModule } from './pods/yield-config/yieldconfig.module';
@@ -187,8 +187,8 @@ describe('DrecModule', () => {
   });
 
   it('should provide SdgBenefit repository', () => {
-    const sdgBenefitRepository = module.get<Repository<SdgBenefit>>(
-      getRepositoryToken(SdgBenefit),
+    const sdgBenefitRepository = module.get<Repository<SDGBenefit>>(
+      getRepositoryToken(SDGBenefit),
     );
     expect(sdgBenefitRepository).toBeDefined();
   });
@@ -223,8 +223,8 @@ describe('DrecModule', () => {
 
   it('should provide DeviceLateongoingIssueCertificateEntity repository', () => {
     const deviceLateongoingIssueCertificateRepository = module.get<
-      Repository<DeviceLateongoingIssueCertificateEntity>
-    >(getRepositoryToken(DeviceLateongoingIssueCertificateEntity));
+      Repository<DeviceLateOngoingIssueCertificateEntity>
+    >(getRepositoryToken(DeviceLateOngoingIssueCertificateEntity));
     expect(deviceLateongoingIssueCertificateRepository).toBeDefined();
   });
 
@@ -317,12 +317,12 @@ describe('DrecModule', () => {
   });
 
   it('should import CountrycodeModule', () => {
-    const countrycodeModule = module.get(CountrycodeModule);
+    const countrycodeModule = module.get(CountryCodeModule);
     expect(countrycodeModule).toBeDefined();
   });
 
   it('should import SdgbenefitModule', () => {
-    const sdgbenefitModule = module.get(SdgbenefitModule);
+    const sdgbenefitModule = module.get(SDGbenefitModule);
     expect(sdgbenefitModule).toBeDefined();
   });
 

--- a/apps/drec-api/src/drec.module.ts
+++ b/apps/drec-api/src/drec.module.ts
@@ -49,7 +49,7 @@ import { HistoryIntermediate_MeterRead } from './pods/reads/history_intermideate
 import { CheckCertificateIssueDateLogForDeviceEntity } from './pods/device/check_certificate_issue_date_log_for_device.entity';
 import { CheckCertificateIssueDateLogForDeviceGroupEntity } from './pods/device-group/check_certificate_issue_date_log_for_device_group.entity';
 import { CountryCodeModule } from './pods/countrycode/countrycode.module';
-import { SDGbenefitModule } from './pods/sdgbenefit/sdgbenefit.module';
+import { SDGBenefitModule } from './pods/sdgbenefit/sdgbenefit.module';
 import { SDGBenefit } from './pods/sdgbenefit/sdgbenefit.entity';
 import { CertificateLogModule } from './pods/certificate-log/certificate-log.module';
 import { HistoryDeviceGroupNextIssueCertificate } from './pods/device-group/history_next_issuance_date_log.entity';
@@ -177,7 +177,7 @@ const QueueingModule = () => {
     AccessControlLayerModuleServiceModule,
     PermissionModule,
     CountryCodeModule,
-    SDGbenefitModule,
+    SDGBenefitModule,
     CertificateLogModule,
     OnChainCertificateModule,
     BlockchainPropertiesModule,

--- a/apps/drec-api/src/drec.module.ts
+++ b/apps/drec-api/src/drec.module.ts
@@ -48,9 +48,9 @@ import { AggregateMeterRead } from './pods/reads/aggregate_readvalue.entity';
 import { HistoryIntermediate_MeterRead } from './pods/reads/history_intermideate_meterread.entity';
 import { CheckCertificateIssueDateLogForDeviceEntity } from './pods/device/check_certificate_issue_date_log_for_device.entity';
 import { CheckCertificateIssueDateLogForDeviceGroupEntity } from './pods/device-group/check_certificate_issue_date_log_for_device_group.entity';
-import { CountrycodeModule } from './pods/countrycode/countrycode.module';
-import { SdgbenefitModule } from './pods/sdgbenefit/sdgbenefit.module';
-import { SdgBenefit } from './pods/sdgbenefit/sdgbenefit.entity';
+import { CountryCodeModule } from './pods/countrycode/countrycode.module';
+import { SDGbenefitModule } from './pods/sdgbenefit/sdgbenefit.module';
+import { SDGBenefit } from './pods/sdgbenefit/sdgbenefit.entity';
 import { CertificateLogModule } from './pods/certificate-log/certificate-log.module';
 import { HistoryDeviceGroupNextIssueCertificate } from './pods/device-group/history_next_issuance_date_log.entity';
 import { DeltaFirstRead } from './pods/reads/delta_firstread.entity';
@@ -60,7 +60,7 @@ import { IrecErrorLogInformationEntity } from './pods/device/irec_error_log_info
 import { OauthClientCredentials } from './pods/user/oauth_client_credentials.entity';
 import { ApiUserEntity } from './pods/user/api-user.entity';
 import { UserLoginSessionEntity } from './pods/user/user_login_session.entity';
-import { DeviceLateongoingIssueCertificateEntity } from './pods/device/device_lateongoing_certificate.entity';
+import { DeviceLateOngoingIssueCertificateEntity } from './pods/device/device_lateongoing_certificate.entity';
 import { CertificateSettingEntity } from './pods/device-group/certificate_setting.entity';
 import { HttpModule } from '@nestjs/axios';
 
@@ -103,12 +103,12 @@ export const entities = [
   HistoryDeviceGroupNextIssueCertificate,
   CheckCertificateIssueDateLogForDeviceEntity,
   CheckCertificateIssueDateLogForDeviceGroupEntity,
-  SdgBenefit,
+  SDGBenefit,
   DeltaFirstRead,
   IrecDevicesInformationEntity,
   IrecErrorLogInformationEntity,
   UserLoginSessionEntity,
-  DeviceLateongoingIssueCertificateEntity,
+  DeviceLateOngoingIssueCertificateEntity,
   CertificateSettingEntity,
   ...IssuerEntities,
   ...OnChainCertificateEntities,
@@ -176,8 +176,8 @@ const QueueingModule = () => {
     YieldConfigModule,
     AccessControlLayerModuleServiceModule,
     PermissionModule,
-    CountrycodeModule,
-    SdgbenefitModule,
+    CountryCodeModule,
+    SDGbenefitModule,
     CertificateLogModule,
     OnChainCertificateModule,
     BlockchainPropertiesModule,

--- a/apps/drec-api/src/models/Delta_firstread.ts
+++ b/apps/drec-api/src/models/Delta_firstread.ts
@@ -1,6 +1,6 @@
 import { Unit } from '@energyweb/energy-api-influxdb';
 
-export interface IDeltaintermediate {
+export interface IDeltaIntermediate {
   id: number;
   unit: Unit;
   readsvalue: number;

--- a/apps/drec-api/src/models/General.ts
+++ b/apps/drec-api/src/models/General.ts
@@ -30,4 +30,4 @@ export const ResponseFailure = (
   message,
 });
 
-export type onUploadProgressFunction = (progressEvent: ProgressEvent) => void;
+export type OnUploadProgressFunction = (progressEvent: ProgressEvent) => void;

--- a/apps/drec-api/src/models/UserRegistrationData.ts
+++ b/apps/drec-api/src/models/UserRegistrationData.ts
@@ -27,7 +27,7 @@ export class UserRegistrationData {
   password: string;
 }
 
-export class UserORGRegistrationData {
+export class UserOrgRegistrationData {
   @IsNotEmpty()
   @IsString()
   firstName: string;

--- a/apps/drec-api/src/pods/admin/admin.controller.ts
+++ b/apps/drec-api/src/pods/admin/admin.controller.ts
@@ -41,7 +41,7 @@ import { UserFilterDTO } from './dto/user-filter.dto';
 import { OrganizationDTO, UpdateOrganizationDTO } from '../organization/dto';
 import { IUser, LoggedInUser, ResponseSuccess } from '../../models';
 // import { CreateUserDTO } from '../user/dto/create-user.dto';
-import { CreateUserORGDTO } from '../user/dto/create-user.dto';
+import { CreateUserOrgDTO } from '../user/dto/create-user.dto';
 import { SeedUserDTO } from './dto/seed-user.dto';
 import { DeviceService } from '../device/device.service';
 import { DeviceGroupService } from '../device-group/device-group.service';
@@ -173,11 +173,11 @@ export class AdminController {
   @ApiResponse({
     status: HttpStatus.OK,
     // type: CreateUserDTO,
-    type: CreateUserORGDTO,
+    type: CreateUserOrgDTO,
     description: 'Returns a new created user',
   })
   public async createUser(
-    @Body() newUser: CreateUserORGDTO,
+    @Body() newUser: CreateUserOrgDTO,
     @UserDecorator() { api_user_id }: LoggedInUser,
   ): Promise<UserDTO> {
     newUser.api_user_id = api_user_id;

--- a/apps/drec-api/src/pods/certificate-log/certificate-log.controller.ts
+++ b/apps/drec-api/src/pods/certificate-log/certificate-log.controller.ts
@@ -32,13 +32,13 @@ import {
 import { UserDecorator } from '../user/decorators/user.decorator';
 import { ILoggedInUser } from '../../models';
 import { DeviceGroupService } from '../device-group/device-group.service';
-import { CertificateNewWithPerDeviceLog, CertificatelogResponse } from './dto';
+import { CertificateNewWithPerDeviceLog, CertificateLogResponse } from './dto';
 import { PowerFormatter } from '../../utils/PowerFormatter';
 import { ActiveUserGuard } from '../../guards/ActiveUserGuard';
 import { PermissionGuard } from '../../guards/PermissionGuard';
 import { Permission } from '../permission/decorators/permission.decorator';
 import { ACLModules } from '../access-control-layer-module-service/decorator/aclModule.decorator';
-import { deviceFilterDTO } from './dto/deviceFilter.dto';
+import { DeviceFilterDTO } from './dto/deviceFilter.dto';
 import { Role } from '../../utils/enums';
 import { OrganizationService } from '../organization/organization.service';
 import { UserService } from '../user/user.service';
@@ -269,7 +269,7 @@ export class CertificateLogController {
     @Query('certiifcateEndDate') generationEndTime?: string,
     @Query('targetVolumeCertificateGenerationRequestedInMegaWattHour')
     targetVolumeCertificateGenerationRequestedInMegaWattHour?: number,
-    @Query('deviceFilter') deviceFilter?: deviceFilterDTO,
+    @Query('deviceFilter') deviceFilter?: DeviceFilterDTO,
   ): Promise<{
     result: any[];
     pageNumber: number;
@@ -298,7 +298,7 @@ export class CertificateLogController {
     description: 'This query parameter is for apiuser',
   })
   @ApiOkResponse({
-    type: [CertificatelogResponse],
+    type: [CertificateLogResponse],
     description: 'Returns issuer Certificate of Reservation',
   })
   async getCertificatesForDeveloper(
@@ -310,7 +310,7 @@ export class CertificateLogController {
       new ValidationPipe({ skipMissingProperties: true }),
     )
     organizationId: number,
-  ): Promise<CertificatelogResponse> {
+  ): Promise<CertificateLogResponse> {
     this.logger.verbose(`With in getCertificatesForDeveloper`);
 
     if (user.role === Role.ApiUser) {

--- a/apps/drec-api/src/pods/certificate-log/certificate-log.service.spec.ts
+++ b/apps/drec-api/src/pods/certificate-log/certificate-log.service.spec.ts
@@ -17,7 +17,7 @@ import {
   Role,
 } from '../../utils/enums';
 import { FilterDTO } from './dto/filter.dto';
-import { CertificatelogResponse } from './dto';
+import { CertificateLogResponse } from './dto';
 
 describe('CertificateLogService', () => {
   let service: CertificateLogService;
@@ -386,7 +386,7 @@ describe('CertificateLogService', () => {
       jest
         .spyOn(service, 'getDeveloperfindCertifiedReservations')
         .mockResolvedValueOnce(
-          expectedCertificates as unknown as CertificatelogResponse,
+          expectedCertificates as unknown as CertificateLogResponse,
         );
 
       const result = await service.getCertifiedlogofDevices(
@@ -529,7 +529,7 @@ describe('CertificateLogService', () => {
           'getDeveloperCertificatesUsingGroupIDVersionUpdateOrigin247',
         )
         .mockResolvedValueOnce(
-          expectedCertificates as unknown as CertificatelogResponse,
+          expectedCertificates as unknown as CertificateLogResponse,
         );
 
       const result = await service.getCertifiedlogofDevices(

--- a/apps/drec-api/src/pods/certificate-log/certificate-log.service.ts
+++ b/apps/drec-api/src/pods/certificate-log/certificate-log.service.ts
@@ -16,7 +16,7 @@ import { DeviceService } from '../device/device.service';
 import {
   CertificateLogResponse,
   CertificateNewWithPerDeviceLog,
-  CertificateWithPerDevicelog,
+  CertificateWithPerDeviceLog,
 } from './dto';
 import { DeviceGroupService } from '../device-group/device-group.service';
 import { DeviceGroupDTO } from '../device-group/dto';
@@ -110,7 +110,7 @@ export class CertificateLogService {
 
     if (certificates.length > 0) {
       const logData =
-        await this.findCertifiedReservations<CertificateWithPerDevicelog>(
+        await this.findCertifiedReservations<CertificateWithPerDeviceLog>(
           certificates,
           groupid,
         );
@@ -172,7 +172,7 @@ export class CertificateLogService {
   ): Promise<T[]> {
     this.logger.verbose(`With in findCertifiedReservations`);
     return await Promise.all(
-      certificates.map(async (certificate: CertificateWithPerDevicelog) =>
+      certificates.map(async (certificate: CertificateWithPerDeviceLog) =>
         this.getCertifiedReservation(
           certificate,
           groupId,
@@ -581,7 +581,7 @@ export class CertificateLogService {
   ): Promise<{
     certificatelog:
       | CertificateNewWithPerDeviceLog[]
-      | CertificateWithPerDevicelog[];
+      | CertificateWithPerDeviceLog[];
     currentpage?: number;
     totalPages: number;
     totalCount: number;
@@ -679,7 +679,7 @@ export class CertificateLogService {
         this.logger.debug(groupedDatasql);
         const result = await newq.getMany();
         const res = await Promise.all(
-          result.map(async (certifiedlist: CertificateWithPerDevicelog) => {
+          result.map(async (certifiedlist: CertificateWithPerDeviceLog) => {
             certifiedlist.certificateStartDate = new Date(
               certifiedlist.generationStartTime * 1000,
             ).toISOString();

--- a/apps/drec-api/src/pods/certificate-log/certificate-log.service.ts
+++ b/apps/drec-api/src/pods/certificate-log/certificate-log.service.ts
@@ -14,9 +14,9 @@ import { Device } from '../device/device.entity';
 import { Certificate } from '@energyweb/issuer-api';
 import { DeviceService } from '../device/device.service';
 import {
-  CertificatelogResponse,
+  CertificateLogResponse,
   CertificateNewWithPerDeviceLog,
-  CertificateWithPerdevicelog,
+  CertificateWithPerDevicelog,
 } from './dto';
 import { DeviceGroupService } from '../device-group/device-group.service';
 import { DeviceGroupDTO } from '../device-group/dto';
@@ -25,7 +25,7 @@ import { ICertificateMetadata } from '../../utils/types';
 import { getLocalTimeZoneFromDevice } from '../../utils/localTimeDetailsForDevice';
 import { CertificateReadModelEntity } from '@energyweb/origin-247-certificate/dist/js/src/offchain-certificate/repositories/CertificateReadModel/CertificateReadModel.entity';
 import { DeviceGroup } from '../device-group/device-group.entity';
-import { deviceFilterDTO } from './dto/deviceFilter.dto';
+import { DeviceFilterDTO } from './dto/deviceFilter.dto';
 import { ILoggedInUser } from '../../models';
 import { Role } from '../../utils/enums';
 import { Response } from 'express';
@@ -110,7 +110,7 @@ export class CertificateLogService {
 
     if (certificates.length > 0) {
       const logData =
-        await this.findCertifiedReservations<CertificateWithPerdevicelog>(
+        await this.findCertifiedReservations<CertificateWithPerDevicelog>(
           certificates,
           groupid,
         );
@@ -172,7 +172,7 @@ export class CertificateLogService {
   ): Promise<T[]> {
     this.logger.verbose(`With in findCertifiedReservations`);
     return await Promise.all(
-      certificates.map(async (certificate: CertificateWithPerdevicelog) =>
+      certificates.map(async (certificate: CertificateWithPerDevicelog) =>
         this.getCertifiedReservation(
           certificate,
           groupId,
@@ -466,7 +466,7 @@ export class CertificateLogService {
   async getsCertificateReadModule(
     userOrgId: string,
     pageNumber: number,
-    deviceFilter: deviceFilterDTO,
+    deviceFilter: DeviceFilterDTO,
     generationStartTime?: string,
     generationEndTime?: string,
     targetVolumeCertificateGenerationRequestedInMegaWattHour?: number,
@@ -581,7 +581,7 @@ export class CertificateLogService {
   ): Promise<{
     certificatelog:
       | CertificateNewWithPerDeviceLog[]
-      | CertificateWithPerdevicelog[];
+      | CertificateWithPerDevicelog[];
     currentpage?: number;
     totalPages: number;
     totalCount: number;
@@ -664,7 +664,7 @@ export class CertificateLogService {
         }
       | any,
     role: Role,
-  ): Promise<CertificatelogResponse> {
+  ): Promise<CertificateLogResponse> {
     const finalcertificatesInReservationWithLog: Array<any> = [];
     this.logger.verbose(`With in getDeveloperfindCertifiedReservations`);
     await Promise.all(
@@ -679,7 +679,7 @@ export class CertificateLogService {
         this.logger.debug(groupedDatasql);
         const result = await newq.getMany();
         const res = await Promise.all(
-          result.map(async (certifiedlist: CertificateWithPerdevicelog) => {
+          result.map(async (certifiedlist: CertificateWithPerDevicelog) => {
             certifiedlist.certificateStartDate = new Date(
               certifiedlist.generationStartTime * 1000,
             ).toISOString();
@@ -813,7 +813,7 @@ export class CertificateLogService {
         }
       | any,
     role: Role,
-  ): Promise<CertificatelogResponse> {
+  ): Promise<CertificateLogResponse> {
     this.logger.verbose(
       `With in getDeveloperCertificatesUsingGroupIDVersionUpdateOrigin247`,
     );

--- a/apps/drec-api/src/pods/certificate-log/dto/certificatewithdevicelog.dto.ts
+++ b/apps/drec-api/src/pods/certificate-log/dto/certificatewithdevicelog.dto.ts
@@ -3,7 +3,7 @@ import { CheckCertificateIssueDateLogForDeviceEntity } from '../../device/check_
 import { ICertificateReadModel } from '@energyweb/origin-247-certificate';
 import { ICertificateMetadata } from '../../../utils/types';
 
-export class CertificateWithPerdevicelog extends Certificate {
+export class CertificateWithPerDevicelog extends Certificate {
   id: number;
   deviceId: string;
   generationStartTime: number;
@@ -25,10 +25,10 @@ export class CertificateNewWithPerDeviceLog {
   perDeviceCertificateLog: CheckCertificateIssueDateLogForDeviceEntity[];
 }
 
-export class CertificatelogResponse {
+export class CertificateLogResponse {
   certificatelog:
     | CertificateNewWithPerDeviceLog[]
-    | CertificateWithPerdevicelog[];
+    | CertificateWithPerDevicelog[];
   totalPages: number;
   totalCount: number;
 }

--- a/apps/drec-api/src/pods/certificate-log/dto/certificatewithdevicelog.dto.ts
+++ b/apps/drec-api/src/pods/certificate-log/dto/certificatewithdevicelog.dto.ts
@@ -3,7 +3,7 @@ import { CheckCertificateIssueDateLogForDeviceEntity } from '../../device/check_
 import { ICertificateReadModel } from '@energyweb/origin-247-certificate';
 import { ICertificateMetadata } from '../../../utils/types';
 
-export class CertificateWithPerDevicelog extends Certificate {
+export class CertificateWithPerDeviceLog extends Certificate {
   id: number;
   deviceId: string;
   generationStartTime: number;
@@ -28,7 +28,7 @@ export class CertificateNewWithPerDeviceLog {
 export class CertificateLogResponse {
   certificatelog:
     | CertificateNewWithPerDeviceLog[]
-    | CertificateWithPerDevicelog[];
+    | CertificateWithPerDeviceLog[];
   totalPages: number;
   totalCount: number;
 }

--- a/apps/drec-api/src/pods/certificate-log/dto/deviceFilter.dto.ts
+++ b/apps/drec-api/src/pods/certificate-log/dto/deviceFilter.dto.ts
@@ -1,6 +1,6 @@
 import { IsOptional, IsArray, IsString, IsNumber } from 'class-validator';
 
-export class deviceFilterDTO {
+export class DeviceFilterDTO {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })

--- a/apps/drec-api/src/pods/countrycode/countrycode.controller.ts
+++ b/apps/drec-api/src/pods/countrycode/countrycode.controller.ts
@@ -13,7 +13,7 @@ import {
   ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
-import { CountrycodeService } from './countrycode.service';
+import { CountryCodeService } from './countrycode.service';
 import { CountryCodeNameDTO, FilterKeyDTO } from './dto';
 
 /*
@@ -23,10 +23,10 @@ import { CountryCodeNameDTO, FilterKeyDTO } from './dto';
 @ApiBearerAuth('access-token')
 @ApiSecurity('drec')
 @Controller('countrycode')
-export class CountrycodeController {
-  private readonly logger = new Logger(CountrycodeController.name);
+export class CountryCodeController {
+  private readonly logger = new Logger(CountryCodeController.name);
 
-  constructor(private readonly countrycodeService: CountrycodeService) {}
+  constructor(private readonly countrycodeService: CountryCodeService) {}
 
   /*
    * It is GET api to get list of all country codes with filteration by pattern(string)

--- a/apps/drec-api/src/pods/countrycode/countrycode.module.ts
+++ b/apps/drec-api/src/pods/countrycode/countrycode.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { CountrycodeController } from './countrycode.controller';
-import { CountrycodeService } from './countrycode.service';
+import { CountryCodeController } from './countrycode.controller';
+import { CountryCodeService } from './countrycode.service';
 @Module({
-  providers: [CountrycodeService],
-  exports: [CountrycodeService],
-  controllers: [CountrycodeController],
+  providers: [CountryCodeService],
+  exports: [CountryCodeService],
+  controllers: [CountryCodeController],
 })
-export class CountrycodeModule {}
+export class CountryCodeModule {}

--- a/apps/drec-api/src/pods/countrycode/countrycode.service.spec.ts
+++ b/apps/drec-api/src/pods/countrycode/countrycode.service.spec.ts
@@ -1,17 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CountrycodeService } from './countrycode.service';
+import { CountryCodeService } from './countrycode.service';
 import { FilterKeyDTO } from './dto';
 import { countryCodesList } from '../../models/country-code';
 
 describe('CountrycodeService', () => {
-  let service: CountrycodeService;
+  let service: CountryCodeService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CountrycodeService],
+      providers: [CountryCodeService],
     }).compile();
 
-    service = module.get<CountrycodeService>(CountrycodeService);
+    service = module.get<CountryCodeService>(CountryCodeService);
   });
 
   it('should be defined', () => {

--- a/apps/drec-api/src/pods/countrycode/countrycode.service.ts
+++ b/apps/drec-api/src/pods/countrycode/countrycode.service.ts
@@ -2,8 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { CountryCodeNameDTO, FilterKeyDTO } from './dto';
 import { countryCodesList } from '../../models/country-code';
 @Injectable()
-export class CountrycodeService {
-  private readonly logger = new Logger(CountrycodeService.name);
+export class CountryCodeService {
+  private readonly logger = new Logger(CountryCodeService.name);
 
   //@InjectRepository(Device) private readonly repository: Repository<Device>,
   public async getCountryCode(

--- a/apps/drec-api/src/pods/device/device.module.ts
+++ b/apps/drec-api/src/pods/device/device.module.ts
@@ -6,18 +6,18 @@ import { Device } from './device.entity';
 import { ACLModulePermissions } from '../permission/permission.entity';
 import { DeviceService } from './device.service';
 import { CheckCertificateIssueDateLogForDeviceEntity } from './check_certificate_issue_date_log_for_device.entity';
-import { CountrycodeModule } from '../countrycode/countrycode.module';
+import { CountryCodeModule } from '../countrycode/countrycode.module';
 import { HistoryIntermediate_MeterRead } from '../reads/history_intermideate_meterread.entity';
 import { IrecDevicesInformationEntity } from './irec_devices_information.entity';
 import { IrecErrorLogInformationEntity } from './irec_error_log_information.entity';
 import { UserModule } from '../user/user.module';
 import { OrganizationModule } from '../organization/organization.module';
-import { DeviceLateongoingIssueCertificateEntity } from './device_lateongoing_certificate.entity';
+import { DeviceLateOngoingIssueCertificateEntity } from './device_lateongoing_certificate.entity';
 import { HttpModule } from '@nestjs/axios';
 @Module({
   imports: [
     forwardRef(() => DeviceGroupModule),
-    CountrycodeModule,
+    CountryCodeModule,
     HttpModule,
     TypeOrmModule.forFeature([
       Device,
@@ -26,7 +26,7 @@ import { HttpModule } from '@nestjs/axios';
       HistoryIntermediate_MeterRead,
       IrecDevicesInformationEntity,
       IrecErrorLogInformationEntity,
-      DeviceLateongoingIssueCertificateEntity,
+      DeviceLateOngoingIssueCertificateEntity,
     ]),
     UserModule,
     OrganizationModule,

--- a/apps/drec-api/src/pods/device/device.service.spec.ts
+++ b/apps/drec-api/src/pods/device/device.service.spec.ts
@@ -36,7 +36,7 @@ import {
 } from '../../utils/enums';
 import { DeviceDescription } from '../../models';
 import { Organization } from '../organization/organization.entity';
-import { DeviceLateongoingIssueCertificateEntity } from './device_lateongoing_certificate.entity';
+import { DeviceLateOngoingIssueCertificateEntity } from './device_lateongoing_certificate.entity';
 import { HttpService } from '@nestjs/axios';
 import { User } from '../user/user.entity';
 import * as deviceUtils from '../../utils/localTimeDetailsForDevice';
@@ -52,7 +52,7 @@ describe('DeviceService', () => {
   let irecerrorlogrepository: Repository<IrecErrorLogInformationEntity>;
   let organizationService: OrganizationService;
   let userService: UserService;
-  let deviceLateOngoingCertificaterepository: DeviceLateongoingIssueCertificateEntity;
+  let deviceLateOngoingCertificaterepository: DeviceLateOngoingIssueCertificateEntity;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -97,7 +97,7 @@ describe('DeviceService', () => {
           useValue: {} as any,
         },
         {
-          provide: getRepositoryToken(DeviceLateongoingIssueCertificateEntity),
+          provide: getRepositoryToken(DeviceLateOngoingIssueCertificateEntity),
           useClass: Repository,
         },
       ],

--- a/apps/drec-api/src/pods/device/device.service.ts
+++ b/apps/drec-api/src/pods/device/device.service.ts
@@ -65,7 +65,7 @@ import { IrecErrorLogInformationEntity } from './irec_error_log_information.enti
 import { getLocalTimeZoneFromDevice } from '../../utils/localTimeDetailsForDevice';
 import { OrganizationService } from '../organization/organization.service';
 import { UserService } from '../user/user.service';
-import { DeviceLateongoingIssueCertificateEntity } from './device_lateongoing_certificate.entity';
+import { DeviceLateOngoingIssueCertificateEntity } from './device_lateongoing_certificate.entity';
 import { HttpService } from '@nestjs/axios';
 import { Organization } from '../organization/organization.entity';
 import { DateTime } from 'luxon';
@@ -86,8 +86,8 @@ export class DeviceService {
     private readonly irecerrorlogrepository: Repository<IrecErrorLogInformationEntity>,
     private readonly organizationService: OrganizationService,
     private readonly userService: UserService,
-    @InjectRepository(DeviceLateongoingIssueCertificateEntity)
-    private readonly latedevciecertificaterepository: Repository<DeviceLateongoingIssueCertificateEntity>,
+    @InjectRepository(DeviceLateOngoingIssueCertificateEntity)
+    private readonly latedevciecertificaterepository: Repository<DeviceLateOngoingIssueCertificateEntity>,
   ) {}
 
   public async find(
@@ -1043,15 +1043,15 @@ export class DeviceService {
   }
   //add new fuction for add window cycle date for late certificate
   public async addLateCertificateIssueDateLogForDevice(
-    params: DeviceLateongoingIssueCertificateEntity,
-  ): Promise<DeviceLateongoingIssueCertificateEntity> {
+    params: DeviceLateOngoingIssueCertificateEntity,
+  ): Promise<DeviceLateOngoingIssueCertificateEntity> {
     this.logger.verbose(`With in AddLateCertificateIssueDateForDevice`);
     return await this.latedevciecertificaterepository.save({
       ...params,
     });
   }
   public async findAllLateCycle(): Promise<
-    DeviceLateongoingIssueCertificateEntity[]
+    DeviceLateOngoingIssueCertificateEntity[]
   > {
     this.logger.verbose(`With in DeviceLateongoingIssueCertificateList`);
     return await this.latedevciecertificaterepository.find({
@@ -1085,7 +1085,7 @@ export class DeviceService {
   public async findoneLateCycle(
     groupid: number,
     externalid: string,
-  ): Promise<DeviceLateongoingIssueCertificateEntity[]> {
+  ): Promise<DeviceLateOngoingIssueCertificateEntity[]> {
     return await this.latedevciecertificaterepository.find({
       where: {
         groupId: groupid,

--- a/apps/drec-api/src/pods/device/device_lateongoing_certificate.entity.ts
+++ b/apps/drec-api/src/pods/device/device_lateongoing_certificate.entity.ts
@@ -4,7 +4,7 @@ import { IsString, IsDate } from 'class-validator';
 import { IDeviceLateOngoingIssueCertificate } from '../../models';
 
 @Entity('device_lateongoing_certificate_cycle')
-export class DeviceLateongoingIssueCertificateEntity
+export class DeviceLateOngoingIssueCertificateEntity
   extends ExtendedBaseEntity
   implements IDeviceLateOngoingIssueCertificate
 {

--- a/apps/drec-api/src/pods/email-confirmation/email-confirmation.service.ts
+++ b/apps/drec-api/src/pods/email-confirmation/email-confirmation.service.ts
@@ -17,7 +17,7 @@ import { User } from '../user/user.entity';
 import { EmailConfirmation } from './email-confirmation.entity';
 import { OauthClientCredentialsService } from '../user/oauth_client.service';
 import { UserService } from '../user/user.service';
-import { CreateUserORGDTO } from '../user/dto/create-user.dto';
+import { CreateUserOrgDTO } from '../user/dto/create-user.dto';
 export interface SuccessResponse {
   success: boolean;
   message: string;
@@ -342,7 +342,7 @@ export class EmailConfirmationService {
   }
 
   public async sendInvitation(
-    inviteuser: any | CreateUserORGDTO,
+    inviteuser: any | CreateUserOrgDTO,
     email: string,
   ): Promise<void> {
     this.logger.verbose(`With in sendInvitation`);

--- a/apps/drec-api/src/pods/file/file-upload.dto.ts
+++ b/apps/drec-api/src/pods/file/file-upload.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class FileUploadDto {
+export class FileUploadDTO {
   @ApiProperty({ type: 'blob', format: 'binary', isArray: true })
   files: Blob[];
   type?: string;

--- a/apps/drec-api/src/pods/file/file.controller.ts
+++ b/apps/drec-api/src/pods/file/file.controller.ts
@@ -26,8 +26,8 @@ import {
 import { Request, Response } from 'express';
 import multer from 'multer';
 
-import { FileDto } from './file.dto';
-import { FileUploadDto } from './file-upload.dto';
+import { FileDTO } from './file.dto';
+import { FileUploadDTO } from './file-upload.dto';
 import { FileService } from './file.service';
 import { UserDecorator } from '../user/decorators/user.decorator';
 import { ILoggedInUser } from '../../models';
@@ -62,7 +62,7 @@ export class FileController {
    */
   @Post()
   @ApiConsumes('multipart/form-data')
-  @ApiBody({ type: FileUploadDto })
+  @ApiBody({ type: FileUploadDTO })
   @UseInterceptors(
     FileFieldsInterceptor([{ name: 'files', maxCount: maxFilesLimit }], {
       storage: multer.memoryStorage(),
@@ -115,7 +115,7 @@ export class FileController {
   @ACLModules('FILE_MANAGEMENT_CRUDL')
   @ApiResponse({
     status: HttpStatus.OK,
-    type: FileDto,
+    type: FileDTO,
     description: 'Download a file',
   })
   @ApiNotFoundResponse({ description: `The file doesn't exist` })

--- a/apps/drec-api/src/pods/file/file.dto.ts
+++ b/apps/drec-api/src/pods/file/file.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 
-export class FileDto {
+export class FileDTO {
   @ApiProperty({ type: 'blob', format: 'binary' })
   @IsNotEmpty()
   data: Buffer;

--- a/apps/drec-api/src/pods/invitation/dto/invite.dto.ts
+++ b/apps/drec-api/src/pods/invitation/dto/invite.dto.ts
@@ -40,7 +40,7 @@ export class InviteDTO {
   @IsOptional()
   status?: string;
 }
-export class updateInviteStatusDTO {
+export class UpdateInviteStatusDTO {
   @ApiProperty({ type: String })
   @IsNotEmpty()
   @IsEmail()

--- a/apps/drec-api/src/pods/invitation/invitation.controller.ts
+++ b/apps/drec-api/src/pods/invitation/invitation.controller.ts
@@ -44,7 +44,7 @@ import { ActiveUserGuard, PermissionGuard, RolesGuard } from '../../guards';
 import { Roles } from '../user/decorators/roles.decorator';
 import { Permission } from '../permission/decorators/permission.decorator';
 import { ACLModules } from '../access-control-layer-module-service/decorator/aclModule.decorator';
-import { InviteDTO, updateInviteStatusDTO } from './dto/invite.dto';
+import { InviteDTO, UpdateInviteStatusDTO } from './dto/invite.dto';
 import { Invitation } from './invitation.entity';
 
 @ApiTags('invitation')
@@ -128,7 +128,7 @@ export class InvitationController {
   async updateInvitation(
     @Param('id') invitationId: number,
     //  @Param('status') status: IOrganizationInvitation['status'],
-    @Body() useracceptinvitation: updateInviteStatusDTO,
+    @Body() useracceptinvitation: UpdateInviteStatusDTO,
     // @UserDecorator() loggedUser: ILoggedInUser,
   ): Promise<SuccessResponseDTO> {
     this.logger.verbose(`With in updateInvitation`);

--- a/apps/drec-api/src/pods/invitation/invitation.service.spec.ts
+++ b/apps/drec-api/src/pods/invitation/invitation.service.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../../utils/enums';
 import { Organization } from '../organization/organization.entity';
 import { User } from '../user/user.entity';
-import { CreateUserORGDTO } from '../user/dto/create-user.dto';
+import { CreateUserOrgDTO } from '../user/dto/create-user.dto';
 import { BadRequestException } from '@nestjs/common';
 import { OrganizationDTO } from '../organization/dto/organization.dto';
 
@@ -504,7 +504,7 @@ describe('InvitationService', () => {
           organizationType: inviteeOrganization.organizationType,
           orgid: orgId,
           api_user_id: inviteeOrganization.api_user_id,
-        } as CreateUserORGDTO,
+        } as CreateUserOrgDTO,
         UserStatus.Pending,
         true,
       );

--- a/apps/drec-api/src/pods/invitation/invitation.service.ts
+++ b/apps/drec-api/src/pods/invitation/invitation.service.ts
@@ -23,7 +23,7 @@ import { Organization } from '../organization/organization.entity';
 import { OrganizationDTO } from '../organization/dto';
 import { MailService } from '../../mail/mail.service';
 import { UpdateInviteStatusDTO } from './dto/invite.dto';
-import { CreateUserORGDTO } from '../user/dto/create-user.dto';
+import { CreateUserOrgDTO } from '../user/dto/create-user.dto';
 import { UserStatus } from '@energyweb/origin-backend-core';
 @Injectable()
 export class InvitationService {
@@ -143,7 +143,7 @@ export class InvitationService {
         return x[Math.floor(Math.random() * x.length)];
       })
       .join('');
-    const inviteuser: CreateUserORGDTO = {
+    const inviteuser: CreateUserOrgDTO = {
       firstName: firstName,
       lastName: lastName,
       email: email.toLowerCase(),

--- a/apps/drec-api/src/pods/invitation/invitation.service.ts
+++ b/apps/drec-api/src/pods/invitation/invitation.service.ts
@@ -22,7 +22,7 @@ import { OrganizationService } from '../organization/organization.service';
 import { Organization } from '../organization/organization.entity';
 import { OrganizationDTO } from '../organization/dto';
 import { MailService } from '../../mail/mail.service';
-import { updateInviteStatusDTO } from './dto/invite.dto';
+import { UpdateInviteStatusDTO } from './dto/invite.dto';
 import { CreateUserORGDTO } from '../user/dto/create-user.dto';
 import { UserStatus } from '@energyweb/origin-backend-core';
 @Injectable()
@@ -169,7 +169,7 @@ export class InvitationService {
   }
 
   public async update(
-    user: updateInviteStatusDTO,
+    user: UpdateInviteStatusDTO,
     invitationId: number,
   ): Promise<ISuccessResponse> {
     this.logger.verbose(`With in update`);

--- a/apps/drec-api/src/pods/issuer/issuer.service.spec.ts
+++ b/apps/drec-api/src/pods/issuer/issuer.service.spec.ts
@@ -17,7 +17,7 @@ import { Organization } from '../organization/organization.entity';
 import { DeviceCsvFileProcessingJobsEntity } from '../device-group/device_csv_processing_jobs.entity';
 import { HistoryIntermediate_MeterRead } from '../reads/history_intermideate_meterread.entity';
 import { HistoryDeviceGroupNextIssueCertificate } from '../device-group/history_next_issuance_date_log.entity';
-import { DeviceLateongoingIssueCertificateEntity } from '../device/device_lateongoing_certificate.entity';
+import { DeviceLateOngoingIssueCertificateEntity } from '../device/device_lateongoing_certificate.entity';
 import { NotFoundException } from '@nestjs/common'; // Adjust the import path as needed
 import { DateTime } from 'luxon';
 import { CheckCertificateIssueDateLogForDeviceGroupEntity } from '../device-group/check_certificate_issue_date_log_for_device_group.entity';
@@ -294,7 +294,7 @@ describe('IssuerService', () => {
       const late_end_date = new Date('2023-01-31');
 
       const mockReturnValue =
-        {} as unknown as DeviceLateongoingIssueCertificateEntity; // or any expected return value
+        {} as unknown as DeviceLateOngoingIssueCertificateEntity; // or any expected return value
 
       const addLateCertificateIssueDateLogForDeviceSpy = jest
         .spyOn(deviceService, 'addLateCertificateIssueDateLogForDevice')

--- a/apps/drec-api/src/pods/issuer/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/issuer.service.ts
@@ -40,7 +40,7 @@ import { HistoryIntermediate_MeterRead } from '../reads/history_intermideate_met
 import { Device } from '../device';
 import { OffChainCertificateService } from '@energyweb/origin-247-certificate';
 import { HistoryNextInssuanceStatus } from '../../utils/enums/history_next_issuance.enum';
-import { DeviceLateongoingIssueCertificateEntity } from '../device/device_lateongoing_certificate.entity';
+import { DeviceLateOngoingIssueCertificateEntity } from '../device/device_lateongoing_certificate.entity';
 @Injectable()
 export class IssuerService {
   private readonly logger = new Logger(IssuerService.name);
@@ -443,9 +443,9 @@ export class IssuerService {
     deviceExternalId: string,
     late_start_date: Date | string | DateTime,
     late_end_date: Date | string | DateTime,
-  ): Promise<DeviceLateongoingIssueCertificateEntity> {
+  ): Promise<DeviceLateOngoingIssueCertificateEntity> {
     const lateDeviceCertificateLogDTO =
-      new DeviceLateongoingIssueCertificateEntity();
+      new DeviceLateOngoingIssueCertificateEntity();
     (lateDeviceCertificateLogDTO.device_externalid = deviceExternalId),
       (lateDeviceCertificateLogDTO.groupId = groupId),
       (lateDeviceCertificateLogDTO.late_start_date =

--- a/apps/drec-api/src/pods/reads/delta_firstread.entity.ts
+++ b/apps/drec-api/src/pods/reads/delta_firstread.entity.ts
@@ -9,14 +9,14 @@ import {
 import { ApiProperty } from '@nestjs/swagger';
 
 import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
-import { IDeltaintermediate } from '../../models/Delta_firstread';
+import { IDeltaIntermediate } from '../../models/Delta_firstread';
 import { Unit } from '@energyweb/energy-api-influxdb';
 @Entity({ name: 'delta_firstread' })
 export class DeltaFirstRead
   extends ExtendedBaseEntity
-  implements IDeltaintermediate
+  implements IDeltaIntermediate
 {
-  constructor(deltafirstreadvalue?: Partial<IDeltaintermediate>) {
+  constructor(deltafirstreadvalue?: Partial<IDeltaIntermediate>) {
     super();
     Object.assign(this, deltafirstreadvalue);
   }

--- a/apps/drec-api/src/pods/sdgbenefit/dto/add_sdgbenefit.dto.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/dto/add_sdgbenefit.dto.ts
@@ -6,7 +6,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { ISdgBenefit } from '../../../models';
 
 @Entity()
-export class SdgBenefitDTO implements Omit<ISdgBenefit, 'id'> {
+export class SDGBenefitDTO implements Omit<ISdgBenefit, 'id'> {
   @ApiProperty()
   @IsString()
   SdgbenefitName: string;

--- a/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.controller.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.controller.ts
@@ -12,10 +12,10 @@ import {
   ApiTags,
   ApiSecurity,
 } from '@nestjs/swagger';
-import { SdgBenefitDTO, SDGBCodeNameDTO } from './dto/add_sdgbenefit.dto';
+import { SDGBenefitDTO, SDGBCodeNameDTO } from './dto/add_sdgbenefit.dto';
 import { SdgbenefitService } from './sdgbenefit.service'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { plainToClass } from 'class-transformer';
-import { SdgBenefit } from './sdgbenefit.entity';
+import { SDGBenefit } from './sdgbenefit.entity';
 @ApiTags('SdgBenefit')
 @ApiBearerAuth('access-token')
 @ApiSecurity('drec')
@@ -31,7 +31,7 @@ export class SdgbenefitController {
    * @returns
    */
   @Post()
-  create(@Body() createsdgbenefitDto: SdgBenefitDTO): Promise<SdgBenefit> {
+  create(@Body() createsdgbenefitDto: SDGBenefitDTO): Promise<SDGBenefit> {
     this.logger.verbose(`With in create`);
     return this.SdgbenefitService.create(createsdgbenefitDto);
   }
@@ -46,7 +46,7 @@ export class SdgbenefitController {
     type: [SDGBCodeNameDTO],
     description: 'Returns all SDGBenefites',
   })
-  findAll(): Promise<SdgBenefit[]> {
+  findAll(): Promise<SDGBenefit[]> {
     this.logger.verbose(`With in findAll`);
     return this.SdgbenefitService.findAll();
   }

--- a/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.controller.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.controller.ts
@@ -13,17 +13,17 @@ import {
   ApiSecurity,
 } from '@nestjs/swagger';
 import { SDGBenefitDTO, SDGBCodeNameDTO } from './dto/add_sdgbenefit.dto';
-import { SdgbenefitService } from './sdgbenefit.service'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { SDGBenefitService } from './sdgbenefit.service'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { plainToClass } from 'class-transformer';
 import { SDGBenefit } from './sdgbenefit.entity';
 @ApiTags('SdgBenefit')
 @ApiBearerAuth('access-token')
 @ApiSecurity('drec')
 @Controller('sdgbenefit')
-export class SdgbenefitController {
-  private readonly logger = new Logger(SdgbenefitController.name);
+export class SDGBenefitController {
+  private readonly logger = new Logger(SDGBenefitController.name);
 
-  constructor(private readonly SdgbenefitService: SdgbenefitService) {}
+  constructor(private readonly SdgbenefitService: SDGBenefitService) {}
 
   /**
    * this Api rout use for add sdg Benifites name and code

--- a/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.entity.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.entity.ts
@@ -4,8 +4,8 @@ import { IsString, IsNumber } from 'class-validator';
 import { ISdgBenefit } from '../../models';
 
 @Entity('sdgbenefit')
-export class SdgBenefit extends ExtendedBaseEntity implements ISdgBenefit {
-  constructor(sdgbenefit: Partial<SdgBenefit>) {
+export class SDGBenefit extends ExtendedBaseEntity implements ISdgBenefit {
+  constructor(sdgbenefit: Partial<SDGBenefit>) {
     super();
     Object.assign(this, sdgbenefit);
   }

--- a/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.module.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.module.ts
@@ -2,10 +2,10 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { SdgbenefitController } from './sdgbenefit.controller';
 import { SdgbenefitService } from './sdgbenefit.service';
-import { SdgBenefit } from './sdgbenefit.entity';
+import { SDGBenefit } from './sdgbenefit.entity';
 @Module({
-  imports: [TypeOrmModule.forFeature([SdgBenefit])],
+  imports: [TypeOrmModule.forFeature([SDGBenefit])],
   controllers: [SdgbenefitController],
   providers: [SdgbenefitService],
 })
-export class SdgbenefitModule {}
+export class SDGbenefitModule {}

--- a/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.module.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { SdgbenefitController } from './sdgbenefit.controller';
-import { SdgbenefitService } from './sdgbenefit.service';
+import { SDGBenefitController } from './sdgbenefit.controller';
+import { SDGBenefitService } from './sdgbenefit.service';
 import { SDGBenefit } from './sdgbenefit.entity';
 @Module({
   imports: [TypeOrmModule.forFeature([SDGBenefit])],
-  controllers: [SdgbenefitController],
-  providers: [SdgbenefitService],
+  controllers: [SDGBenefitController],
+  providers: [SDGBenefitService],
 })
 export class SDGbenefitModule {}

--- a/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.service.spec.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.service.spec.ts
@@ -4,26 +4,26 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { SdgbenefitService } from './sdgbenefit.service';
-import { SdgBenefit } from './sdgbenefit.entity';
+import { SDGBenefit } from './sdgbenefit.entity';
 
 describe('SdgbenefitService', () => {
   let service: SdgbenefitService;
-  let repository: Repository<SdgBenefit>;
+  let repository: Repository<SDGBenefit>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SdgbenefitService,
         {
-          provide: getRepositoryToken(SdgBenefit),
+          provide: getRepositoryToken(SDGBenefit),
           useClass: Repository,
         },
       ],
     }).compile();
 
     service = module.get<SdgbenefitService>(SdgbenefitService);
-    repository = module.get<Repository<SdgBenefit>>(
-      getRepositoryToken(SdgBenefit),
+    repository = module.get<Repository<SDGBenefit>>(
+      getRepositoryToken(SDGBenefit),
     );
   });
 

--- a/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.service.spec.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.service.spec.ts
@@ -3,17 +3,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { SdgbenefitService } from './sdgbenefit.service';
+import { SDGBenefitService } from './sdgbenefit.service';
 import { SDGBenefit } from './sdgbenefit.entity';
 
 describe('SdgbenefitService', () => {
-  let service: SdgbenefitService;
+  let service: SDGBenefitService;
   let repository: Repository<SDGBenefit>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        SdgbenefitService,
+        SDGBenefitService,
         {
           provide: getRepositoryToken(SDGBenefit),
           useClass: Repository,
@@ -21,7 +21,7 @@ describe('SdgbenefitService', () => {
       ],
     }).compile();
 
-    service = module.get<SdgbenefitService>(SdgbenefitService);
+    service = module.get<SDGBenefitService>(SDGBenefitService);
     repository = module.get<Repository<SDGBenefit>>(
       getRepositoryToken(SDGBenefit),
     );

--- a/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.service.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.service.ts
@@ -6,8 +6,8 @@ import { SDGBenefitDTO, SDGBCodeNameDTO } from './dto/add_sdgbenefit.dto';
 import { SDGBenefit } from './sdgbenefit.entity';
 import { SDGBenefits } from '../../models/Sdgbenefit';
 @Injectable()
-export class SdgbenefitService {
-  private readonly logger = new Logger(SdgbenefitService.name);
+export class SDGBenefitService {
+  private readonly logger = new Logger(SDGBenefitService.name);
 
   constructor(
     @InjectRepository(SDGBenefit)

--- a/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.service.ts
+++ b/apps/drec-api/src/pods/sdgbenefit/sdgbenefit.service.ts
@@ -2,26 +2,26 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
-import { SdgBenefitDTO, SDGBCodeNameDTO } from './dto/add_sdgbenefit.dto';
-import { SdgBenefit } from './sdgbenefit.entity';
+import { SDGBenefitDTO, SDGBCodeNameDTO } from './dto/add_sdgbenefit.dto';
+import { SDGBenefit } from './sdgbenefit.entity';
 import { SDGBenefits } from '../../models/Sdgbenefit';
 @Injectable()
 export class SdgbenefitService {
   private readonly logger = new Logger(SdgbenefitService.name);
 
   constructor(
-    @InjectRepository(SdgBenefit)
-    private readonly repository: Repository<SdgBenefit>,
+    @InjectRepository(SDGBenefit)
+    private readonly repository: Repository<SDGBenefit>,
   ) {}
 
-  public async create(createTestapiDto: SdgBenefitDTO): Promise<SdgBenefit> {
+  public async create(createTestapiDto: SDGBenefitDTO): Promise<SDGBenefit> {
     this.logger.verbose(`With in create`);
     return await this.repository.save({
       ...createTestapiDto,
     });
   }
 
-  public async findAll(): Promise<SdgBenefit[]> {
+  public async findAll(): Promise<SDGBenefit[]> {
     this.logger.verbose(`With in findAll`);
     return this.repository.find();
   }

--- a/apps/drec-api/src/pods/user/dto/create-user.dto.ts
+++ b/apps/drec-api/src/pods/user/dto/create-user.dto.ts
@@ -37,7 +37,7 @@ import { Role } from '../../../utils/enums/role.enum';
 
 // }
 
-export class CreateUserORGDTO
+export class CreateUserOrgDTO
   extends PickType(UserDTO, ['firstName', 'lastName', 'email'] as const)
   implements UserOrgRegistrationData
 {

--- a/apps/drec-api/src/pods/user/dto/create-user.dto.ts
+++ b/apps/drec-api/src/pods/user/dto/create-user.dto.ts
@@ -9,7 +9,7 @@ import {
   IsOptional,
   IsUUID,
 } from 'class-validator';
-import { UserORGRegistrationData } from '../../../models';
+import { UserOrgRegistrationData } from '../../../models';
 import { Match } from '../decorators/match.decorator';
 // export class CreateUserDTO
 //   extends PickType(UserDTO, [
@@ -35,12 +35,12 @@ import { Match } from '../decorators/match.decorator';
 
 // }
 
-export class CreateUserORGDTO
+export class CreateUserOrgDTO
   extends IntersectionType(
     PickType(UserDTO, ['firstName', 'lastName', 'email'] as const),
     PickType(OrganizationDTO, ['organizationType'] as const),
   )
-  implements UserORGRegistrationData
+  implements UserOrgRegistrationData
 {
   @ApiProperty({ type: String })
   @MaxLength(20)

--- a/apps/drec-api/src/pods/user/user.controller.ts
+++ b/apps/drec-api/src/pods/user/user.controller.ts
@@ -27,7 +27,7 @@ import {
 import { UserDecorator } from './decorators/user.decorator';
 import { UserDTO } from './dto/user.dto';
 import { UserService } from './user.service';
-import { CreateUserORGDTO } from './dto/create-user.dto';
+import { CreateUserOrgDTO } from './dto/create-user.dto';
 import { IEmailConfirmationToken, ILoggedInUser } from '../../models';
 import {
   ActiveUserGuard,
@@ -113,7 +113,7 @@ export class UserController {
    * @returns {UserDTO}
    */
   @Post('register')
-  @ApiBody({ type: CreateUserORGDTO })
+  @ApiBody({ type: CreateUserOrgDTO })
   @UseGuards(WithoutAuthGuard, PermissionGuard)
   @Permission('Write')
   @ACLModules('USER_MANAGEMENT_CRUDL')
@@ -123,7 +123,7 @@ export class UserController {
     description: 'Register a new user ',
   })
   public async register(
-    @Body() userRegistrationData: CreateUserORGDTO,
+    @Body() userRegistrationData: CreateUserOrgDTO,
     @Req() request: Request,
   ): Promise<UserDTO> {
     const user = request.user;

--- a/apps/drec-api/src/pods/user/user.service.spec.ts
+++ b/apps/drec-api/src/pods/user/user.service.spec.ts
@@ -16,7 +16,7 @@ import { OauthClientCredentialsService } from './oauth_client.service';
 import { OrganizationService } from '../organization/organization.service';
 import { ApiUserEntity } from './api-user.entity';
 import { UserLoginSessionEntity } from './user_login_session.entity';
-import { CreateUserORGDTO } from './dto/create-user.dto';
+import { CreateUserOrgDTO } from './dto/create-user.dto';
 import { Organization } from '../organization/organization.entity';
 import {
   OrganizationStatus,
@@ -109,7 +109,7 @@ describe('UserService', () => {
 
   describe('newCreateUser', () => {
     it('should create a new user with valid input data when it is not invite', async () => {
-      const userData: CreateUserORGDTO = {
+      const userData: CreateUserOrgDTO = {
         firstName: 'test',
         lastName: 'ApiUser',
         email: 'testsweya3@gmail.com',
@@ -119,7 +119,7 @@ describe('UserService', () => {
         orgName: 'DIRECT_ORG_DEVELOPER1',
         orgAddress: 'Chennai',
         api_user_id: uuid(),
-      } as CreateUserORGDTO;
+      } as CreateUserOrgDTO;
 
       const orgData: Organization = {
         id: 1,
@@ -207,7 +207,7 @@ describe('UserService', () => {
         .spyOn(organizationService, 'isNameAlreadyTaken')
         .mockResolvedValue(true);
 
-      const userData: CreateUserORGDTO = {
+      const userData: CreateUserOrgDTO = {
         firstName: 'test',
         lastName: 'ApiUser',
         email: 'testsweya5@gmail.com',
@@ -217,7 +217,7 @@ describe('UserService', () => {
         orgName: 'DIRECT_ORG_DEVELOPER1',
         orgAddress: 'Chennai',
         api_user_id: uuid(),
-      } as CreateUserORGDTO;
+      } as CreateUserOrgDTO;
 
       const mockOrganizationEntity = {
         id: 1,
@@ -283,7 +283,7 @@ describe('UserService', () => {
         .mockResolvedValue(true);
 
       // Test data
-      const userData: CreateUserORGDTO = {
+      const userData: CreateUserOrgDTO = {
         firstName: 'test',
         lastName: 'ApiUser',
         email: 'testsweya5@gmail.com',
@@ -293,7 +293,7 @@ describe('UserService', () => {
         orgName: 'DIRECT_ORG_DEVELOPER1',
         orgAddress: 'Chennai',
         api_user_id: uuid(),
-      } as CreateUserORGDTO;
+      } as CreateUserOrgDTO;
 
       const mockOrganizationEntity = {
         id: 1,

--- a/apps/drec-api/src/pods/user/user.service.ts
+++ b/apps/drec-api/src/pods/user/user.service.ts
@@ -25,7 +25,7 @@ import {
   UserChangePasswordUpdate,
 } from '../../models';
 import { Role, UserStatus, UserPermissionStatus } from '../../utils/enums';
-import { CreateUserORGDTO } from './dto/create-user.dto';
+import { CreateUserOrgDTO } from './dto/create-user.dto';
 import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
 import { validate } from 'class-validator';
 import { UserRole } from './user_role.entity';
@@ -59,7 +59,7 @@ export class UserService {
   ) {}
 
   public async seed(
-    data: CreateUserORGDTO,
+    data: CreateUserOrgDTO,
 
     organizationId: number | null,
     role?: Role,
@@ -81,7 +81,7 @@ export class UserService {
   }
 
   public async newCreateUser(
-    data: CreateUserORGDTO,
+    data: CreateUserOrgDTO,
     status?: UserStatus,
     inviteuser?: boolean,
   ): Promise<UserDTO> {
@@ -161,7 +161,7 @@ export class UserService {
   }
 
   public async createUserByAdmin(
-    data: CreateUserORGDTO,
+    data: CreateUserOrgDTO,
     status?: UserStatus,
     inviteuser?: boolean,
   ): Promise<UserDTO> {
@@ -577,7 +577,7 @@ export class UserService {
   }
 
   public async sendUserInvitation(
-    inviteuser: CreateUserORGDTO,
+    inviteuser: CreateUserOrgDTO,
     email: string,
   ): Promise<{
     message: string;

--- a/apps/drec-api/test/seed.ts
+++ b/apps/drec-api/test/seed.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { OrganizationService } from '../src/pods/organization/organization.service';
 import { UserService } from '../src/pods/user/user.service';
-import { CreateUserORGDTO } from '../src/pods/user/dto/create-user.dto';
+import { CreateUserOrgDTO } from '../src/pods/user/dto/create-user.dto';
 import { Role } from '../src/utils/enums/role.enum';
 import { DeviceDTO, NewDeviceDTO } from '../src/pods/device/dto';
 import {
@@ -64,7 +64,7 @@ export const testOrgs: OrganizationDTO[] = [
   },
 ];
 
-export const testUsers: Omit<CreateUserORGDTO, 'organizationId'>[] = [
+export const testUsers: Omit<CreateUserOrgDTO, 'organizationId'>[] = [
   {
     firstName: 'Jane',
     lastName: 'Williams',

--- a/apps/drec-api/test/user.e2e-spec.ts
+++ b/apps/drec-api/test/user.e2e-spec.ts
@@ -10,7 +10,7 @@ import { OrganizationService } from '../src/pods/organization/organization.servi
 import { seed } from './seed';
 import { expect } from 'chai';
 import { DeviceService } from '../src/pods/device/device.service';
-import { CreateUserORGDTO } from '../src/pods/user/dto/create-user.dto';
+import { CreateUserOrgDTO } from '../src/pods/user/dto/create-user.dto';
 import { UserRegistrationData } from '../src/models';
 import { UpdateUserProfileDTO } from '../src/pods/user/dto/update-user-profile.dto';
 import { UpdateOwnUserSettingsDTO } from '../src/pods/user/dto/update-own-user-settings.dto';
@@ -87,7 +87,7 @@ describe('Users tests', () => {
       password: 'Password123',
     };
     await loginUser(loggedUser);
-    const partialUser: CreateUserORGDTO = {
+    const partialUser: CreateUserOrgDTO = {
       firstName: 'test',
       lastName: 'user2021',
       email: 'test-1-2021@mailinator.com',
@@ -98,7 +98,7 @@ describe('Users tests', () => {
   });
 
   it('should register a new user', async () => {
-    const partialUser: CreateUserORGDTO = {
+    const partialUser: CreateUserOrgDTO = {
       firstName: 'test',
       lastName: 'user2021',
       email: 'test-2-2021@mailinator.com',
@@ -145,7 +145,7 @@ describe('Users tests', () => {
   const postAdminUser = async (
     url: string,
     status: HttpStatus,
-    body: CreateUserORGDTO,
+    body: CreateUserOrgDTO,
   ): Promise<any> =>
     await request(app.getHttpServer())
       .post(`/admin/users/${url}`)
@@ -158,7 +158,7 @@ describe('Users tests', () => {
   const postUser = async (
     url: string,
     status: HttpStatus,
-    body: CreateUserORGDTO,
+    body: CreateUserOrgDTO,
   ): Promise<any> =>
     await request(app.getHttpServer())
       .post(`/user/${url}`)


### PR DESCRIPTION
### Renaming class names and types to PascalCase
We wanted to rename all the class names, typescript types and enums used in the project to PascalCase

### Issue ticket #469 and[ link](https://github.com/orgs/d-rec/projects/2/views/1?pane=issue&itemId=89125573&issue=d-rec%7Cdrec-origin%7C469)

### What I did

- Renamed all class names, typescript types, and enums used in the project to PascalCase
- Didn't rename anything else. Functions, variables, constants, and file names are out of scope for this ticket
- Made sure that the test run and nothing breaks

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] No existing features have been broken without good reason.
- [x] The code style guideline have been followed
- [x] Documentation has been updated to reflect your changes.
