### PR TITLE
feat: add and integrate Redocly library for documenting api endpoints…

### DIFF
--- a/apps/drec-api/package.json
+++ b/apps/drec-api/package.json
@@ -113,6 +113,7 @@
     "pg": "8.7.1",
     "pkcs7-padding": "0.1.1",
     "qs": "^6.10.3",
+    "redoc-express": "^2.1.0",
     "reflect-metadata": "^0.1.13",
     "rijndael-js": "2.0.0",
     "rimraf": "^3.0.2",

--- a/apps/drec-api/pnpm-lock.yaml
+++ b/apps/drec-api/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@energyweb/energy-api-influxdb':
         specifier: 0.8.3
-        version: 0.8.3(@nestjs/platform-express@8.1.1)(swagger-ui-express@4.1.6(express@4.19.2))
+        version: 0.8.3(@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1))(swagger-ui-express@4.1.6(express@4.19.2))
       '@energyweb/issuer':
         specifier: 6.0.2-alpha.1646058469.0
         version: 6.0.2-alpha.1646058469.0
       '@energyweb/issuer-api':
         specifier: 0.7.1
-        version: 0.7.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(@nestjs/cqrs@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/typeorm@8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1)))(class-transformer@0.3.1)(express@4.19.2)(ioredis@5.4.2)(passport@0.4.1)(reflect-metadata@0.1.14)
+        version: 0.7.1(q7jocbgtmg3l7qyzqhkroyoczy)
       '@energyweb/origin-247-certificate':
         specifier: 4.1.5
-        version: 4.1.5(@energyweb/issuer@6.0.2-alpha.1646058469.0)(@nestjs/bull@0.4.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(bull@3.29.3))(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(@nestjs/cqrs@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/typeorm@8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1)))(ioredis@5.4.2)
+        version: 4.1.5(rf6lhhdspeqnd2v334q2wzk6h4)
       '@energyweb/origin-backend':
         specifier: 11.2.3
         version: 11.2.3(ioredis@5.4.2)(pg@8.7.1)(swagger-ui-express@4.1.6(express@4.19.2))
@@ -28,7 +28,7 @@ importers:
         version: 8.2.3
       '@energyweb/origin-backend-utils':
         specifier: 1.8.2-alpha.1646058469.0
-        version: 1.8.2-alpha.1646058469.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))
+        version: 1.8.2-alpha.1646058469.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))
       '@energyweb/utils-general':
         specifier: 11.2.2-alpha.1646058469.0
         version: 11.2.2-alpha.1646058469.0
@@ -43,13 +43,13 @@ importers:
         version: 2.0.4
       '@nestjs-modules/mailer':
         specifier: 2.0.2
-        version: 2.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(nodemailer@6.9.9)
+        version: 2.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(nodemailer@6.9.9)
       '@nestjs/axios':
         specifier: ~0.0.3
         version: 0.0.8(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/bull':
         specifier: 0.4.2
-        version: 0.4.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(bull@3.29.3)
+        version: 0.4.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(bull@3.29.3)
       '@nestjs/common':
         specifier: 8.1.1
         version: 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -61,7 +61,7 @@ importers:
         version: 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/cqrs':
         specifier: 8.0.0
-        version: 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+        version: 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/jwt':
         specifier: ~10.2.0
         version: 10.2.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))
@@ -73,16 +73,16 @@ importers:
         version: 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)
       '@nestjs/schedule':
         specifier: 1.0.1
-        version: 1.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)
+        version: 1.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)
       '@nestjs/swagger':
         specifier: 5.2.1
-        version: 5.2.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))
+        version: 5.2.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))
       '@nestjs/typeorm':
         specifier: 8.0.2
-        version: 8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))
+        version: 8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))
       '@sentry/nestjs':
         specifier: ^8.42.0
-        version: 8.50.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)
+        version: 8.50.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))
       '@sentry/node':
         specifier: ^8.42.0
         version: 8.50.0
@@ -203,6 +203,9 @@ importers:
       qs:
         specifier: ^6.10.3
         version: 6.14.0
+      redoc-express:
+        specifier: ^2.1.0
+        version: 2.1.0
       reflect-metadata:
         specifier: ^0.1.13
         version: 0.1.14
@@ -254,7 +257,7 @@ importers:
         version: 10.3.2(uglify-js@2.6.0)
       '@nestjs/testing':
         specifier: 8.1.1
-        version: 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(@nestjs/platform-express@8.1.1)
+        version: 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1))
       '@types/bcryptjs':
         specifier: 2.4.2
         version: 2.4.2
@@ -5891,6 +5894,9 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  redoc-express@2.1.0:
+    resolution: {integrity: sha512-gq6FvghNirD3dCJ7w8Z6escXYHnU1Hk50baQsIeGunQQ9YRoy6qR/MjEOJtDEKaPNB2NgkIzQ9ESNX5/27zkDA==}
+
   reflect-metadata@0.1.13:
     resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
 
@@ -8054,13 +8060,13 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@energyweb/energy-api-influxdb@0.8.3(@nestjs/platform-express@8.1.1)(swagger-ui-express@4.1.6(express@4.19.2))':
+  '@energyweb/energy-api-influxdb@0.8.3(@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1))(swagger-ui-express@4.1.6(express@4.19.2))':
     dependencies:
       '@influxdata/influxdb-client': 1.21.0
       '@nestjs/common': 8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1)
       '@nestjs/config': 1.1.6(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(reflect-metadata@0.1.13)(rxjs@7.5.1)
-      '@nestjs/core': 8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.5.1)
-      '@nestjs/swagger': 5.1.5(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/core@8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.5.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))
+      '@nestjs/core': 8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1))(reflect-metadata@0.1.13)(rxjs@7.5.1)
+      '@nestjs/swagger': 5.1.5(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/core@8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1))(reflect-metadata@0.1.13)(rxjs@7.5.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))
       class-transformer: 0.3.1
       class-validator: 0.13.2
       reflect-metadata: 0.1.13
@@ -8076,20 +8082,20 @@ snapshots:
       - fastify-swagger
       - swagger-ui-express
 
-  '@energyweb/issuer-api@0.7.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(@nestjs/cqrs@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/typeorm@8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1)))(class-transformer@0.3.1)(express@4.19.2)(ioredis@5.4.2)(passport@0.4.1)(reflect-metadata@0.1.14)':
+  '@energyweb/issuer-api@0.7.1(q7jocbgtmg3l7qyzqhkroyoczy)':
     dependencies:
       '@energyweb/issuer': 7.0.1
       '@energyweb/origin-backend-core': 8.2.3
-      '@energyweb/origin-backend-utils': 1.8.3(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))
+      '@energyweb/origin-backend-utils': 1.8.3(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))
       '@energyweb/utils-general': 11.2.3
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/config': 1.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.4.0)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/cqrs': 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/cqrs': 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/passport': 8.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(passport@0.4.1)
-      '@nestjs/schedule': 1.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)
-      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))
-      '@nestjs/typeorm': 8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))
+      '@nestjs/schedule': 1.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)
+      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))
+      '@nestjs/typeorm': 8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))
       class-validator: 0.13.2
       cryptr: 6.0.2
       ethers: 5.3.1
@@ -8161,14 +8167,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@energyweb/origin-247-certificate@4.1.5(@energyweb/issuer@6.0.2-alpha.1646058469.0)(@nestjs/bull@0.4.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(bull@3.29.3))(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(@nestjs/cqrs@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/typeorm@8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1)))(ioredis@5.4.2)':
+  '@energyweb/origin-247-certificate@4.1.5(rf6lhhdspeqnd2v334q2wzk6h4)':
     dependencies:
       '@energyweb/issuer': 6.0.2-alpha.1646058469.0
-      '@nestjs/bull': 0.4.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(bull@3.29.3)
+      '@nestjs/bull': 0.4.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(bull@3.29.3)
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/cqrs': 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/typeorm': 8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))
+      '@nestjs/cqrs': 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/typeorm': 8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))
       bull: 3.29.3
       cache-manager-ioredis: 2.1.0
       class-transformer: 0.4.0
@@ -8216,13 +8222,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@energyweb/origin-backend-utils@1.8.2-alpha.1646058469.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))':
+  '@energyweb/origin-backend-utils@1.8.2-alpha.1646058469.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))':
     dependencies:
       '@energyweb/origin-backend-core': 8.2.2-alpha.1646058469.0
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/config': 1.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.4.0)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))
+      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))
       bn.js: 5.2.0
       class-validator: 0.13.2
       pg: 8.7.1
@@ -8252,13 +8258,13 @@ snapshots:
       - typeorm-aurora-data-api-driver
       - utf-8-validate
 
-  '@energyweb/origin-backend-utils@1.8.3(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))':
+  '@energyweb/origin-backend-utils@1.8.3(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0))(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))':
     dependencies:
       '@energyweb/origin-backend-core': 8.2.3
-      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/config': 1.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.13)(rxjs@7.4.0)
-      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/config': 1.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))
       bn.js: 5.2.0
       class-validator: 0.13.2
       pg: 8.7.1
@@ -8288,13 +8294,13 @@ snapshots:
       - typeorm-aurora-data-api-driver
       - utf-8-validate
 
-  '@energyweb/origin-backend-utils@1.8.3(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))':
+  '@energyweb/origin-backend-utils@1.8.3(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))':
     dependencies:
       '@energyweb/origin-backend-core': 8.2.3
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/config': 1.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.4.0)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))
+      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))
       bn.js: 5.2.0
       class-validator: 0.13.2
       pg: 8.7.1
@@ -8327,17 +8333,17 @@ snapshots:
   '@energyweb/origin-backend@11.2.3(ioredis@5.4.2)(pg@8.7.1)(swagger-ui-express@4.1.6(express@4.19.2))':
     dependencies:
       '@energyweb/origin-backend-core': 8.2.3
-      '@energyweb/origin-backend-utils': 1.8.3(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))
+      '@energyweb/origin-backend-utils': 1.8.3(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0))(class-transformer@0.3.1)(ioredis@5.4.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))
       '@energyweb/utils-general': 11.2.3
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
-      '@nestjs/config': 1.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.13)(rxjs@7.4.0)
-      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)
-      '@nestjs/cqrs': 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)
-      '@nestjs/jwt': 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))
-      '@nestjs/passport': 8.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(passport@0.5.2)
-      '@nestjs/platform-express': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)
-      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))
-      '@nestjs/typeorm': 8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))
+      '@nestjs/config': 1.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/cqrs': 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0))(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/jwt': 8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))
+      '@nestjs/passport': 8.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(passport@0.5.2)
+      '@nestjs/platform-express': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1)
+      '@nestjs/swagger': 5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))
+      '@nestjs/typeorm': 8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0))(reflect-metadata@0.1.13)(rxjs@7.4.0)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))
       bcryptjs: 2.4.3
       body-parser: 1.19.1
       class-transformer: 0.3.1
@@ -9103,7 +9109,7 @@ snapshots:
       simple-statistics: 2.5.0
       tile-cover: 3.0.1
 
-  '@nestjs-modules/mailer@2.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(nodemailer@6.9.9)':
+  '@nestjs-modules/mailer@2.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(nodemailer@6.9.9)':
     dependencies:
       '@css-inline/css-inline': 0.14.1
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -9132,7 +9138,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@nestjs/bull@0.4.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(bull@3.29.3)':
+  '@nestjs/bull@0.4.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(bull@3.29.3)':
     dependencies:
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -9221,9 +9227,9 @@ snapshots:
       rxjs: 7.8.1
       uuid: 8.3.2
 
-  '@nestjs/config@1.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.13)(rxjs@7.4.0)':
+  '@nestjs/config@1.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(reflect-metadata@0.1.13)(rxjs@7.4.0)':
     dependencies:
-      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
       lodash.get: 4.4.2
@@ -9255,9 +9261,9 @@ snapshots:
       rxjs: 7.5.1
       uuid: 8.3.2
 
-  '@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)':
+  '@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)':
     dependencies:
-      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
@@ -9268,7 +9274,7 @@ snapshots:
       tslib: 2.3.1
       uuid: 8.3.2
     optionalDependencies:
-      '@nestjs/platform-express': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)
+      '@nestjs/platform-express': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1)
     transitivePeerDependencies:
       - encoding
 
@@ -9289,7 +9295,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/core@8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.5.1)':
+  '@nestjs/core@8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1))(reflect-metadata@0.1.13)(rxjs@7.5.1)':
     dependencies:
       '@nestjs/common': 8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1)
       '@nuxtjs/opencollective': 0.3.2
@@ -9306,14 +9312,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/cqrs@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)':
+  '@nestjs/cqrs@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0))(reflect-metadata@0.1.13)(rxjs@7.4.0)':
     dependencies:
-      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)
       reflect-metadata: 0.1.13
       rxjs: 7.4.0
 
-  '@nestjs/cqrs@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)':
+  '@nestjs/cqrs@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.8.1)':
     dependencies:
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -9326,15 +9332,15 @@ snapshots:
       '@types/jsonwebtoken': 9.0.5
       jsonwebtoken: 9.0.2
 
-  '@nestjs/jwt@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))':
+  '@nestjs/jwt@8.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))':
     dependencies:
-      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
       '@types/jsonwebtoken': 8.5.4
       jsonwebtoken: 8.5.1
 
-  '@nestjs/mapped-types@1.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)':
+  '@nestjs/mapped-types@1.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)':
     dependencies:
-      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
       class-transformer: 0.3.1
       class-validator: 0.13.2
       reflect-metadata: 0.1.13
@@ -9361,15 +9367,27 @@ snapshots:
       class-transformer: 0.3.1
       class-validator: 0.14.0
 
+  '@nestjs/passport@8.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(passport@0.5.2)':
+    dependencies:
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      passport: 0.5.2
+
   '@nestjs/passport@8.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(passport@0.4.1)':
     dependencies:
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       passport: 0.4.1
 
-  '@nestjs/passport@8.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(passport@0.5.2)':
+  '@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1)':
     dependencies:
-      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      passport: 0.5.2
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      body-parser: 1.19.0
+      cors: 2.8.5
+      express: 4.17.1
+      multer: 1.4.3
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)':
     dependencies:
@@ -9383,7 +9401,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/schedule@1.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)':
+  '@nestjs/schedule@1.0.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)':
     dependencies:
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -9402,11 +9420,11 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))':
+  '@nestjs/swagger@5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))':
     dependencies:
-      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/mapped-types': 1.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/mapped-types': 1.0.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)
       lodash: 4.17.21
       path-to-regexp: 3.2.0
       reflect-metadata: 0.1.13
@@ -9416,7 +9434,7 @@ snapshots:
       - class-transformer
       - class-validator
 
-  '@nestjs/swagger@5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))':
+  '@nestjs/swagger@5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))':
     dependencies:
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -9430,7 +9448,7 @@ snapshots:
       - class-transformer
       - class-validator
 
-  '@nestjs/swagger@5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))':
+  '@nestjs/swagger@5.1.4(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(swagger-ui-express@4.2.0(express@4.19.2))':
     dependencies:
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -9444,10 +9462,10 @@ snapshots:
       - class-transformer
       - class-validator
 
-  '@nestjs/swagger@5.1.5(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/core@8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.5.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))':
+  '@nestjs/swagger@5.1.5(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/core@8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1))(reflect-metadata@0.1.13)(rxjs@7.5.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(swagger-ui-express@4.1.6(express@4.19.2))':
     dependencies:
       '@nestjs/common': 8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1)
-      '@nestjs/core': 8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.5.1)
+      '@nestjs/core': 8.2.4(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1))(reflect-metadata@0.1.13)(rxjs@7.5.1)
       '@nestjs/mapped-types': 1.0.0(@nestjs/common@8.2.4(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.5.1))(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)
       lodash: 4.17.21
       path-to-regexp: 3.2.0
@@ -9458,7 +9476,7 @@ snapshots:
       - class-transformer
       - class-validator
 
-  '@nestjs/swagger@5.2.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))':
+  '@nestjs/swagger@5.2.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(swagger-ui-express@4.1.6(express@4.19.2))':
     dependencies:
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -9472,7 +9490,7 @@ snapshots:
       - class-transformer
       - class-validator
 
-  '@nestjs/testing@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(@nestjs/platform-express@8.1.1)':
+  '@nestjs/testing@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1))':
     dependencies:
       optional: 0.1.4
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -9481,16 +9499,16 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)
 
-  '@nestjs/typeorm@8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))':
+  '@nestjs/typeorm@8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0))(reflect-metadata@0.1.13)(rxjs@7.4.0)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))':
     dependencies:
-      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0)
+      '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.4.0))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.13)(rxjs@7.4.0)
       reflect-metadata: 0.1.13
       rxjs: 7.4.0
       typeorm: 0.2.41(ioredis@5.4.2)(pg@8.7.1)
       uuid: 8.3.2
 
-  '@nestjs/typeorm@8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))':
+  '@nestjs/typeorm@8.0.2(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.2.41(ioredis@5.4.2)(pg@8.7.1))':
     dependencies:
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -9827,7 +9845,7 @@ snapshots:
 
   '@sentry/core@8.50.0': {}
 
-  '@sentry/nestjs@8.50.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1)':
+  '@sentry/nestjs@8.50.0(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1))':
     dependencies:
       '@nestjs/common': 8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 8.1.1(@nestjs/common@8.1.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@8.1.1)(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -14977,6 +14995,8 @@ snapshots:
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+
+  redoc-express@2.1.0: {}
 
   reflect-metadata@0.1.13: {}
 

--- a/apps/drec-api/src/auth/auth.controller.ts
+++ b/apps/drec-api/src/auth/auth.controller.ts
@@ -11,13 +11,13 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { Request as ExpressRequest } from 'express';
 import { IUser } from '../models';
-import { ApiBearerAuth, ApiBody, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { AuthService } from './auth.service';
 import { LoginReturnDataDTO } from './dto/login-return-data.dto';
 import { LoginDataDTO } from './dto/login-data.dto';
 import { WithoutAuthGuard } from '../guards';
-@ApiTags('auth')
+@ApiTags('Auth')
 @ApiBearerAuth('access-token')
 @Controller()
 export class AuthController {
@@ -32,6 +32,11 @@ export class AuthController {
   @Post('auth/login')
   @HttpCode(HttpStatus.OK)
   @ApiBody({ type: LoginDataDTO })
+  @ApiOperation({
+    summary: 'Login',
+    description:
+      'Authenticates a user using their email and password and returns an authentication token',
+  })
   @ApiResponse({
     status: HttpStatus.OK,
     type: LoginReturnDataDTO,

--- a/apps/drec-api/src/auth/auth.controller.ts
+++ b/apps/drec-api/src/auth/auth.controller.ts
@@ -11,7 +11,13 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { Request as ExpressRequest } from 'express';
 import { IUser } from '../models';
-import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
 import { AuthService } from './auth.service';
 import { LoginReturnDataDTO } from './dto/login-return-data.dto';

--- a/apps/drec-api/src/index.ts
+++ b/apps/drec-api/src/index.ts
@@ -6,6 +6,7 @@ import { useContainer } from 'class-validator';
 import fs from 'fs';
 import { DRECModule } from './drec.module';
 import * as PortUtils from './port';
+import Redoc from 'redoc-express';
 
 export { DRECModule };
 
@@ -55,6 +56,19 @@ export async function startAPI(logger?: LoggerService): Promise<any> {
 
   const document = SwaggerModule.createDocument(app, options);
   SwaggerModule.setup('swagger', app, document);
+
+  app.use(
+    '/redoc',
+    Redoc({
+      title: 'D-REC Origin API',
+      specUrl: '/swagger-json',
+      nonce: '',
+    }),
+  );
+
+  app.use('/swagger-json', (req, res) => {
+    res.json(document);
+  });
 
   await app.listen(PORT);
 

--- a/apps/drec-api/src/index.ts
+++ b/apps/drec-api/src/index.ts
@@ -1,12 +1,13 @@
 import 'reflect-metadata';
 import { LoggerService, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { SwaggerModule } from '@nestjs/swagger';
 import { useContainer } from 'class-validator';
 import fs from 'fs';
 import { DRECModule } from './drec.module';
 import * as PortUtils from './port';
 import Redoc from 'redoc-express';
+import { getDocumentBuilder } from './swagger';
 
 export { DRECModule };
 
@@ -44,15 +45,8 @@ export async function startAPI(logger?: LoggerService): Promise<any> {
     app.useLogger(logger);
   }
 
-  const options = new DocumentBuilder()
-    .setTitle('D-REC Origin API')
-    .setDescription('Swagger documentation for D-REC Origin API')
-    .setVersion('0.1')
-    .addBearerAuth(
-      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
-      'access-token',
-    )
-    .build();
+  const documentBuilder = getDocumentBuilder();
+  const options = documentBuilder.build();
 
   const document = SwaggerModule.createDocument(app, options);
   SwaggerModule.setup('swagger', app, document);

--- a/apps/drec-api/src/index.ts
+++ b/apps/drec-api/src/index.ts
@@ -58,7 +58,7 @@ export async function startAPI(logger?: LoggerService): Promise<any> {
   SwaggerModule.setup('swagger', app, document);
 
   app.use(
-    '/redoc',
+    '/docs',
     Redoc({
       title: 'D-REC Origin API',
       specUrl: '/swagger-json',

--- a/apps/drec-api/src/swagger/index.ts
+++ b/apps/drec-api/src/swagger/index.ts
@@ -1,0 +1,19 @@
+import { DocumentBuilder } from '@nestjs/swagger';
+import Tags from './tags';
+
+export const getDocumentBuilder = (): DocumentBuilder => {
+  const options = new DocumentBuilder()
+    .setTitle('D-REC Origin API')
+    .setDescription(
+      'This document outlines the D-REC Origin API Specification to accompany Version 1. The functionality outlined within each API interaction represents the recommended minimum required details necessary to implement a request on the D-REC Origin API',
+    )
+    .setVersion('0.1')
+    .addBearerAuth(
+      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      'access-token',
+    );
+
+  Tags.forEach((tag) => options.addTag(tag.name, tag.description));
+
+  return options;
+};

--- a/apps/drec-api/src/swagger/tags.ts
+++ b/apps/drec-api/src/swagger/tags.ts
@@ -6,5 +6,4 @@ const tags: { name: string; description: string }[] = [
   },
 ];
 
-
 export default tags;

--- a/apps/drec-api/src/swagger/tags.ts
+++ b/apps/drec-api/src/swagger/tags.ts
@@ -1,0 +1,10 @@
+const tags: { name: string; description: string }[] = [
+  {
+    name: 'Auth',
+    description:
+      'All endpoints related to user authentication and authorization. It covers functionalities such as login, registration, token issuance and verification, password recovery, and session management. Endpoints under this tag are designed to secure the API by verifying user credentials, managing access tokens, and ensuring that only authenticated users can interact with protected resources. This separation helps developers quickly identify and integrate security-related operations within the API.',
+  },
+];
+
+
+export default tags;

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -103,6 +103,7 @@ specifiers:
   pkcs7-padding: 0.1.1
   prettier: ~3.2.5
   qs: ^6.10.3
+  redoc-express: ^2.1.0
   reflect-metadata: ^0.1.13
   rijndael-js: 2.0.0
   rimraf: ^3.0.2
@@ -228,6 +229,7 @@ dependencies:
   pkcs7-padding: 0.1.1
   prettier: 3.2.5
   qs: 6.12.1
+  redoc-express: 2.1.0
   reflect-metadata: 0.1.14
   rijndael-js: 2.0.0
   rimraf: 3.0.2
@@ -12161,6 +12163,10 @@ packages:
       redis-errors: 1.2.0
     dev: false
 
+  /redoc-express/2.1.0:
+    resolution: {integrity: sha512-gq6FvghNirD3dCJ7w8Z6escXYHnU1Hk50baQsIeGunQQ9YRoy6qR/MjEOJtDEKaPNB2NgkIzQ9ESNX5/27zkDA==}
+    dev: false
+
   /reflect-metadata/0.1.13:
     resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
     dev: false
@@ -14283,7 +14289,7 @@ packages:
     dev: false
 
   file:projects/origin-drec-api.tgz:
-    resolution: {integrity: sha512-I0KYHPVbId38vAo8wM/OlzgKOdVG8VEb3TWDvvkq7K8R+H6JrLyJTNRCCK9iKBpcOnfIh8cvq4gL6MGdBJgnww==, tarball: file:projects/origin-drec-api.tgz}
+    resolution: {integrity: sha512-XBqxQha2NgPxhI42tK4rLMbWevn5TcQeyb68jSwzG+W9MEnbf7TOimmbCQRI0b+NWpFsUkWr9LF+nhGgR49L1Q==, tarball: file:projects/origin-drec-api.tgz}
     name: '@rush-temp/origin-drec-api'
     version: 0.0.0
     dependencies:
@@ -14382,6 +14388,7 @@ packages:
       pkcs7-padding: 0.1.1
       prettier: 3.2.5
       qs: 6.12.1
+      redoc-express: 2.1.0
       reflect-metadata: 0.1.14
       rijndael-js: 2.0.0
       rimraf: 3.0.2


### PR DESCRIPTION
### Describe your changes

We wanted an alternative library that we could use such as [Redocly](https://redocly.com/redoc) which can provide detailed API documentation with examples and this Pr is integrating it.
 - After starting the application you may access the redocly documentation on this URL : `http://localhost:3040/redoc/`
### Issue ticket [#515](https://github.com/orgs/d-rec/projects/2/views/8?pane=issue&itemId=99156455&issue=d-rec%7Cdrec-origin%7C515)


### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] No existing features have been broken without good reason.
- [x] The code style guideline have been followed
- [x] Documentation has been updated to reflect your changes.

### Dependency installation

- `pnpm install`

### Document explaining the libraries used

https://foggy-vision-eaf.notion.site/API-Documentation-Libraries-1abb90efd819809f99b5dbc0add76e89?pvs=4
