### PR TITLE
Ft/create meter read table

### DIFF
--- a/apps/drec-api/CHANGELOG.md
+++ b/apps/drec-api/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.4.4](https://github.com/d-rec/drec-origin/compare/v0.4.3...v0.4.4) (2025-05-29)
+
+### Features
+
+- create device indexes for lateongoing certificates ([#624](https://github.com/d-rec/drec-origin/issues/624)) ([5eb8dc8](https://github.com/d-rec/drec-origin/commit/5eb8dc8043683ffe8ba4e370674280879dd4816c))
+
 ### [0.4.3](https://github.com/d-rec/drec-origin/compare/v0.4.2...v0.4.3) (2025-05-26)
 
 ### Bug Fixes

--- a/apps/drec-api/migrations/1748254777228-AddIndexesForDeviceLateongoingCertificateCycle.ts
+++ b/apps/drec-api/migrations/1748254777228-AddIndexesForDeviceLateongoingCertificateCycle.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIndexesToDeviceLateongoingCertificateCycle1748259999999
+  implements MigrationInterface
+{
+  name = 'AddIndexesToDeviceLateongoingCertificateCycle1748259999999';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX "IDX_dlcc_group_active_unissued"
+      ON "device_lateongoing_certificate_cycle" ("groupId")
+      WHERE "archived_at" IS NULL AND "certificate_issued" = false;
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_dlcc_group_externalid_active_unissued"
+      ON "device_lateongoing_certificate_cycle" ("groupId", "device_externalid")
+      WHERE "archived_at" IS NULL AND "certificate_issued" = false;
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_dlcc_group_externalid_active"
+      ON "device_lateongoing_certificate_cycle" ("groupId", "device_externalid")
+      WHERE "archived_at" IS NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_dlcc_group_active_unissued"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_dlcc_group_externalid_active_unissued"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_dlcc_group_externalid_active"`,
+    );
+  }
+}

--- a/apps/drec-api/migrations/1749457186148-MeterReads.ts
+++ b/apps/drec-api/migrations/1749457186148-MeterReads.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MeterReads1749457186148 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS citext`);
+
+    await queryRunner.query(`
+                CREATE TABLE "meter_reads" (
+                    "id" SERIAL PRIMARY KEY,
+                    "external_id" citext NOT NULL,
+                    "type" VARCHAR NOT NULL,
+                    "value" DOUBLE PRECISION NOT NULL,
+                    "unit" VARCHAR NOT NULL,
+                    "start_date" TIMESTAMP NOT NULL,
+                    "end_date" TIMESTAMP NOT NULL,
+                    "certified" BOOLEAN DEFAULT FALSE,
+                    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT now(),
+                    "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT now(),
+                    CONSTRAINT "fk_meter_reads_device" 
+                        FOREIGN KEY ("external_id") 
+                        REFERENCES "device"("externalId") 
+                        ON DELETE CASCADE
+                )
+            `);
+
+    await queryRunner.query(`
+                CREATE INDEX "idx_meter_reads_external_id" 
+                ON "meter_reads" ("external_id")
+            `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+                ALTER TABLE "meter_reads" 
+                DROP CONSTRAINT "fk_meter_reads_device"
+            `);
+
+    await queryRunner.query(`DROP TABLE "meter_reads"`);
+
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "idx_meter_reads_external_id"`,
+    );
+  }
+}

--- a/apps/drec-api/package.json
+++ b/apps/drec-api/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@energyweb/origin-drec-api",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "",
   "main": "dist/js/src/index.js",
   "author": "EnergyWeb DevHub GmbH; Florin Georgescu, florin.georgescu@energyweb.org",

--- a/apps/drec-api/src/drec.module.ts
+++ b/apps/drec-api/src/drec.module.ts
@@ -70,6 +70,7 @@ import { BulkUploadEntity } from './pods/bulk-upload/bulk-uploads.entity';
 import { BulkUploadFailedLogEntity } from './pods/bulk-upload/bulk-uploads-failed-logs.entity';
 import { BulkUploadModule } from './pods/bulk-upload/bulk-upload.module';
 import { HealthModule } from './pods/health/health.module';
+import { MeterRead } from './pods/reads/meter-reads.entity';
 const getEnvFilePath = () => {
   const pathsToTest = [
     '../../../.env',
@@ -105,6 +106,7 @@ export const entities = [
   DeviceCsvProcessingFailedRowsEntity,
   DeviceGroupNextIssueCertificate,
   AggregateMeterRead,
+  MeterRead,
   HistoryIntermediateMeterRead,
   HistoryDeviceGroupNextIssueCertificate,
   CheckCertificateIssueDateLogForDeviceEntity,

--- a/apps/drec-api/src/pods/issuer/services/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/services/issuer.service.ts
@@ -252,10 +252,7 @@ export class IssuerService {
     }
 
     // Get the latest read for the device
-    const lastReads = await this.readsService.latestRead(
-      device.externalId,
-      device.createdAt,
-    );
+    const lastReads = await this.readsService.latestRead(device.externalId);
 
     if (!lastReads.length) return output;
 

--- a/apps/drec-api/src/pods/issuer/services/late-ongoing-issuance.service.ts
+++ b/apps/drec-api/src/pods/issuer/services/late-ongoing-issuance.service.ts
@@ -152,7 +152,7 @@ export class LateOngoingIssuanceService {
 
     // Fetch last read and next issuance data in parallel
     const [lastRead, nextIssuance] = await Promise.all([
-      this.readsService.latestRead(device.externalId, device.createdAt),
+      this.readsService.latestRead(device.externalId),
       this.groupService.getGroupCertificateIssueDate({ groupId: group.id }),
     ]);
 

--- a/apps/drec-api/src/pods/reads/meter-reads.entity.ts
+++ b/apps/drec-api/src/pods/reads/meter-reads.entity.ts
@@ -1,0 +1,57 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { IsEnum } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Unit } from '@energyweb/energy-api-influxdb';
+import { ReadType } from '../../utils/enums';
+
+@Entity({ name: 'meter_reads' })
+export class MeterRead {
+  @ApiProperty({ type: Number })
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ApiProperty()
+  @Column({
+    name: 'external_id',
+    type: 'citext',
+  })
+  externalId: string;
+
+  @ApiProperty({ enum: ReadType, enumName: 'type' })
+  @Column()
+  @IsEnum(ReadType)
+  type: ReadType;
+
+  @ApiProperty()
+  @Column({ type: 'double precision' })
+  value: number;
+
+  @ApiProperty({ enum: Unit, enumName: 'unit' })
+  @Column()
+  @IsEnum(Unit)
+  unit: Unit;
+
+  @ApiProperty()
+  @Column({ type: 'timestamp', name: 'start_date' })
+  startDate: Date;
+
+  @ApiProperty()
+  @Column({ type: 'timestamp', name: 'end_date' })
+  endDate: Date;
+
+  @ApiProperty()
+  @Column({ default: false })
+  certified: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/apps/drec-api/src/pods/reads/reads.controller.ts
+++ b/apps/drec-api/src/pods/reads/reads.controller.ts
@@ -135,7 +135,7 @@ export class ReadsController extends BaseReadsController {
   public async getReads(
     @Param('externalId') meterId: string,
     @Query() filter: FilterDTO,
-  ): Promise<ReadDTO[]> {
+  ): Promise<any> {
     this.logger.verbose(`With in getReads`);
     const device: DeviceDTO | null =
       await this.deviceService.findReads(meterId);
@@ -147,7 +147,10 @@ export class ReadsController extends BaseReadsController {
         message: `Invalid device id`,
       });
     }
-    return super.getReads(device.externalId, filter);
+    return await this.internalReadsService.getByExternalId(
+      device.externalId,
+      filter,
+    );
   }
 
   /**
@@ -338,10 +341,6 @@ export class ReadsController extends BaseReadsController {
       this.logger.log(
         'THE RETURNED OBJECT KEYS:::' + Object.keys(returnedObject),
       );
-      Object.assign(returnedObject, { timezone: timezone });
-      this.logger.log(
-        'THE CHANGED OBJECT KEYS::::::' + Object.keys(returnedObject),
-      );
       return returnedObject;
     } else {
       this.logger.error(`Invalid readType parameter`);
@@ -518,38 +517,28 @@ export class ReadsController extends BaseReadsController {
       });
     }
 
-    let latestReadObject;
-
     const deviceExternalId = device.externalId;
+    const latestReadObject =
+      await this.internalReadsService.latestRead(deviceExternalId);
 
-    if (!device.meterReadtype) {
-      this.logger.error(`Read not found`);
-      throw new HttpException('Read not found', 400);
-    } else {
-      latestReadObject = await this.internalReadsService.latestRead(
-        deviceExternalId,
-        device.createdAt,
-      );
-
-      if (
-        typeof latestReadObject === 'undefined' ||
-        latestReadObject.length == 0
-      ) {
-        this.logger.error(`Read Not found`);
-        throw new HttpException('Read Not found', 400);
-      }
-      if (user.role === 'Buyer' || user.role === 'ApiUser') {
-        return {
-          externalId: device.developerExternalId,
-          timestamp: latestReadObject[0].timestamp,
-          value: latestReadObject[0].value,
-        };
-      }
-
+    if (
+      typeof latestReadObject === 'undefined' ||
+      latestReadObject.length == 0
+    ) {
+      this.logger.error(`Read Not found`);
+      throw new HttpException('Read Not found', 400);
+    }
+    if (user.role === 'Buyer' || user.role === 'ApiUser') {
       return {
-        enddate: latestReadObject[0].timestamp,
-        value: latestReadObject[0].value,
+        externalId: device.developerExternalId,
+        timestamp: latestReadObject.endDate,
+        value: latestReadObject.value,
       };
     }
+
+    return {
+      enddate: latestReadObject.endDate,
+      value: latestReadObject.value,
+    };
   }
 }

--- a/apps/drec-api/src/pods/reads/reads.module.ts
+++ b/apps/drec-api/src/pods/reads/reads.module.ts
@@ -21,6 +21,7 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { DeviceModule } from '../device/device.module';
 import { defaultBullJobOptions } from '../../config/bull.config';
 import { Queues } from '../../utils/enums/queues.enum';
+import { MeterRead } from './meter-reads.entity';
 
 const baseReadServiceProvider = {
   provide: BASE_READ_SERVICE,
@@ -38,6 +39,7 @@ const baseReadServiceProvider = {
   imports: [
     TypeOrmModule.forFeature([
       AggregateMeterRead,
+      MeterRead,
       HistoryIntermediateMeterRead,
       DeltaFirstRead,
     ]),

--- a/apps/drec-api/src/pods/reads/reads.service.ts
+++ b/apps/drec-api/src/pods/reads/reads.service.ts
@@ -29,14 +29,12 @@ import { InfluxDB, Point, QueryApi } from '@influxdata/influxdb-client';
 import { EventBus } from '@nestjs/cqrs';
 import { InjectRepository } from '@nestjs/typeorm';
 import axios from 'axios';
-import { BigNumber } from 'ethers';
 import { DeviceDTO } from '../device/dto';
 import { DeviceGroupService } from '../device-group/device-group.service';
 import { AggregateMeterRead } from './aggregate_readvalue.entity';
 import { flattenDeep, values, groupBy, mean, sum } from 'lodash';
 import { DeltaFirstRead } from './delta_firstread.entity';
 import { DateTime } from 'luxon';
-import { GenerationReadingStoredEvent } from '../../events/GenerationReadingStored.event';
 import { writePoints } from '../../lib/influx-db';
 import { IAggregateIntermediate } from '../../models';
 import { HistoryNextIssuanceStatus } from '../../utils/enums/history_next_issuance.enum';
@@ -74,6 +72,7 @@ import {
   DEVICE_DEGRADATION,
   INFLUX_DB_TIMEOUT,
 } from '../../constants';
+import { MeterRead } from './meter-reads.entity';
 
 export type TUserBaseEntity = ExtendedBaseEntity & IAggregateIntermediate;
 @Injectable()
@@ -83,6 +82,8 @@ export class ReadsService {
   private readonly queryApi: QueryApi;
 
   constructor(
+    @InjectRepository(MeterRead)
+    private readonly readsRepository: Repository<MeterRead>,
     @InjectRepository(AggregateMeterRead)
     private readonly repository: Repository<AggregateMeterRead>,
     @InjectRepository(HistoryIntermediateMeterRead)
@@ -203,40 +204,6 @@ export class ReadsService {
       },
       take: 1,
     });
-  }
-
-  public async storeRead(
-    id: string,
-    measurements: NewIntermediateMeterReadDTO,
-  ): Promise<void> {
-    this.logger.debug('DREC is storing smart meter reads:');
-    this.logger.debug(JSON.stringify(measurements));
-    const device = await this.deviceService.findReads(id);
-    if (!device) {
-      throw new NotFoundException(`No device found with external id ${id}`);
-    }
-
-    if (
-      device.timezone === null &&
-      measurements.timezone !== null &&
-      measurements.timezone !== undefined &&
-      measurements.timezone.toString().trim() !== ''
-    ) {
-      await this.deviceService.updateTimezone(
-        device.externalId,
-        measurements.timezone,
-      );
-    }
-
-    const roundedMeasurements = this.roundMeasurementsToUnit(measurements);
-
-    const filteredMeasurements = await this.filterMeasurements(
-      id,
-      roundedMeasurements,
-      device,
-    );
-    this.logger.verbose(filteredMeasurements);
-    await this.storeGenerationReading(id, filteredMeasurements, device);
   }
 
   private roundMeasurementsToUnit(
@@ -707,31 +674,29 @@ export class ReadsService {
     deviceId: string,
     startDate: Date,
     endDate: Date,
-  ): SelectQueryBuilder<HistoryIntermediateMeterRead> {
+  ): SelectQueryBuilder<any> {
     this.logger.verbose(startDate);
     this.logger.verbose(endDate);
 
-    return this.historyRepository
-      .createQueryBuilder('devicehistory')
-      .where('devicehistory.externalId = :deviceId', { deviceId })
+    return this.readsRepository
+      .createQueryBuilder('reads')
+      .where('reads.external_id = :deviceId', { deviceId })
       .andWhere(
-        new Brackets((db) => {
-          db.where(
-            'devicehistory.readsStartDate BETWEEN :startDateFirstWhere AND :endDateFirstWhere ',
-            { startDateFirstWhere: startDate, endDateFirstWhere: endDate },
-          )
-            .orWhere(
-              'devicehistory.readsEndDate BETWEEN :startDateSecondtWhere AND :endDateSecondWhere',
-              { startDateSecondtWhere: startDate, endDateSecondWhere: endDate },
-            )
-            .orWhere(
-              ':startdateThirdWhere BETWEEN devicehistory.readsStartDate AND devicehistory.readsEndDate',
-              { startdateThirdWhere: startDate },
-            )
-            .orWhere(
-              ':enddateforthdWhere BETWEEN devicehistory.readsStartDate AND devicehistory.readsEndDate',
-              { enddateforthdWhere: endDate },
-            );
+        new Brackets((qb) => {
+          qb.where('reads.start_date BETWEEN :startDate AND :endDate', {
+            startDate,
+            endDate,
+          })
+            .orWhere('reads.end_date BETWEEN :startDate AND :endDate', {
+              startDate,
+              endDate,
+            })
+            .orWhere(':startDate BETWEEN reads.start_date AND reads.end_date', {
+              startDate,
+            })
+            .orWhere(':endDate BETWEEN reads.start_date AND reads.end_date', {
+              endDate,
+            });
         }),
       );
   }
@@ -912,40 +877,6 @@ export class ReadsService {
     }
   }
 
-  private async storeGenerationReading(
-    id: string,
-    measurements: MeasurementDTO,
-    device: DeviceDTO,
-  ): Promise<void> {
-    const organization = await this.organizationService.findOne(
-      device.organizationId,
-    );
-
-    if (!organization) {
-      throw new NotFoundException(
-        `No organization found with device organization code ${device.organizationId}`,
-      );
-    }
-    await this.store(id, measurements);
-
-    for (const measurement of measurements.reads) {
-      const startTime = DateTime.fromJSDate(measurement.timestamp)
-        .minus({ minutes: 30 })
-        .toJSDate();
-      const endTime = DateTime.fromJSDate(measurement.timestamp).toJSDate();
-
-      this.eventBus.publish(
-        new GenerationReadingStoredEvent({
-          deviceId: id,
-          energyValue: BigNumber.from(measurement.value),
-          fromTime: startTime,
-          toTime: endTime,
-          organizationId: organization.id.toString(),
-        }),
-      );
-    }
-  }
-
   private aggregateArray(aggregate: Aggregate, array: number[]): number {
     switch (aggregate) {
       case Aggregate.Mean:
@@ -1085,8 +1016,8 @@ export class ReadsService {
         400,
       );
     }
-    const historyReads = [];
-    let ongoing = [];
+    const reads = [];
+    const ongoing = [];
     this.logger.verbose(
       'page number:::::::::::::::::::::::::::::::::::::::::::' + pageNumber,
     );
@@ -1098,7 +1029,7 @@ export class ReadsService {
       filter.start,
       filter.end,
     );
-    let numberOfOngReads = 0;
+    const numberOfOngReads = 0;
     let numberOfReads = numberOfHistoryReads + numberOfOngReads;
     if (numberOfHistoryReads > 0) {
       numberOfPages = Math.ceil(numberOfHistoryReads / sizeOfPage);
@@ -1108,12 +1039,6 @@ export class ReadsService {
       filter.offset = sizeOfPage * (pageNumber - 1);
       filter.limit = sizeOfPage;
     }
-    numberOfOngReads = await this.getNumberOfOngoingReads(
-      filter.start,
-      filter.end,
-      externalId,
-      deviceOnboarded,
-    );
     this.logger.verbose(numberOfOngReads);
     if (numberOfOngReads > numberOfHistoryReads) {
       numberOfPages = Math.ceil(numberOfOngReads / sizeOfPage);
@@ -1121,7 +1046,7 @@ export class ReadsService {
     numberOfReads = numberOfHistoryReads + numberOfOngReads;
     if (numberOfHistoryReads == 0 && numberOfOngReads == 0) {
       return {
-        historyread: historyReads,
+        reads: reads,
         ongoing,
         numberOfReads: numberOfReads,
         numberOfPages: 0,
@@ -1134,7 +1059,7 @@ export class ReadsService {
       pageNumber > numberOfPages
     ) {
       return {
-        historyread: historyReads,
+        reads: reads,
         ongoing,
         numberOfReads: numberOfReads,
         numberOfPages: numberOfPages,
@@ -1162,10 +1087,11 @@ export class ReadsService {
           .getRawMany();
 
         await rawHistoryReads.forEach((element) => {
-          historyReads.push({
-            startdate: element.devicehistory_readsStartDate,
-            enddate: element.devicehistory_readsEndDate,
-            value: element.devicehistory_readsvalue,
+          reads.push({
+            type: element.reads_type,
+            startdate: element.reads_start_date,
+            enddate: element.reads_end_date,
+            value: element.reads_value,
           });
         });
       } catch (error) {
@@ -1185,118 +1111,32 @@ export class ReadsService {
           filter.end.toString(),
       );
 
-      let readsFilter: FilterDTO = {
-        offset: filter.offset,
-        limit: filter.limit,
-        start: filter.start.toString(),
-        end: filter.end.toString(),
-      };
-      if (
-        new Date(filter.start).getTime() > new Date(deviceOnboarded).getTime()
-      ) {
-        readsFilter = {
-          offset: filter.offset,
-          limit: filter.limit,
-          start: filter.start.toString(),
-          end: filter.end.toString(),
+      // this.logger.verbose(
+      //   'count of ong reads:::::::::::::::::::::::::::::::::::' +
+      //     (await this.getNumberOfOngoingReads(
+      //       filter.start,
+      //       filter.end,
+      //       externalId,
+      //       deviceOnboarded,
+      //     )),
+      // );
+      if (typeof pageNumber === 'number' && !isNaN(pageNumber)) {
+        return {
+          reads: reads,
+          ongoing,
+          numberOfReads: numberOfReads,
+          numberOfPages: numberOfPages,
+          currentPageNumber: pageNumber,
         };
       } else {
-        readsFilter = {
-          offset: filter.offset,
-          limit: filter.limit,
-          start: deviceOnboarded.toString(),
-          end: filter.end.toString(),
+        return {
+          reads: reads,
+          ongoing,
+          numberOfReads: numberOfReads,
+          numberOfPages: numberOfPages,
+          currentPageNumber: 1,
         };
       }
-      if (
-        new Date(filter.start).getTime() <
-          new Date(deviceOnboarded).getTime() ||
-        new Date(filter.end).getTime() > new Date(deviceOnboarded).getTime()
-      ) {
-        const finalOngoingRead = await this.getPaginatedData(
-          externalId,
-          readsFilter,
-          pageNumber,
-        );
-
-        let previousReadTime;
-        if (pageNumber > 1) {
-          const previousPage = pageNumber - 1;
-          const previousPageData = await this.getPaginatedData(
-            externalId,
-            readsFilter,
-            previousPage,
-          );
-          if (previousPageData.length > 0) {
-            previousReadTime = (previousPageData[0] as any).timestamp;
-            this.logger.verbose(
-              'previous page read data[0]::::' +
-                (previousPageData[0] as any).timestamp,
-            );
-          } else {
-            previousReadTime = null;
-          }
-        }
-        const transformedFinalOngoing = [];
-        for (let i = 0; i < finalOngoingRead.length; i++) {
-          const currentRead = finalOngoingRead[i];
-          let startDate;
-          if (i === 0 && pageNumber == 1) {
-            startDate = new Date(
-              Math.max(
-                new Date(deviceOnboarded).getTime(),
-                new Date(filter.start).getTime(),
-              ),
-            );
-          } else if (i == 0 && pageNumber != 1) {
-            startDate = previousReadTime;
-          } else {
-            startDate = transformedFinalOngoing[i - 1].enddate;
-          }
-          const endDate = (finalOngoingRead[i] as any).timestamp;
-          if (i > 1) {
-            transformedFinalOngoing.push({
-              startdate: transformedFinalOngoing[i - 1].enddate,
-              enddate: endDate,
-              value: (currentRead as any).value,
-            });
-          } else {
-            transformedFinalOngoing.push({
-              startdate: startDate,
-              enddate: endDate,
-              value: (currentRead as any).value,
-            });
-          }
-        }
-        ongoing = transformedFinalOngoing;
-      }
-    }
-
-    this.logger.verbose(
-      'count of ong reads:::::::::::::::::::::::::::::::::::' +
-        (await this.getNumberOfOngoingReads(
-          filter.start,
-          filter.end,
-          externalId,
-          deviceOnboarded,
-        )),
-    );
-    if (typeof pageNumber === 'number' && !isNaN(pageNumber)) {
-      return {
-        historyread: historyReads,
-        ongoing,
-        numberOfReads: numberOfReads,
-        numberOfPages: numberOfPages,
-        currentPageNumber: pageNumber,
-      };
-    } else {
-      return {
-        historyread: historyReads,
-        ongoing,
-        numberOfReads: numberOfReads,
-        numberOfPages: numberOfPages,
-        currentPageNumber: 1,
-      };
     }
   }
 
@@ -1305,39 +1145,12 @@ export class ReadsService {
     startDate: Date | string,
     endDate: Date | string,
   ): Promise<any> {
-    const query = this.historyRepository
-      .createQueryBuilder('devicehistory')
-      .where('devicehistory.externalId = :deviceId', { deviceId })
-      .andWhere('devicehistory.readsStartDate <= :endDate', { endDate })
-      .andWhere('devicehistory.readsEndDate >= :startDate', { startDate });
-
+    const query = this.readsRepository
+      .createQueryBuilder('reads')
+      .where('reads.external_id = :deviceId', { deviceId })
+      .andWhere('reads.start_date <= :endDate', { endDate })
+      .andWhere('reads.end_date >= :startDate', { startDate });
     return await query.getCount();
-  }
-
-  async getNumberOfOngoingReads(
-    start: Date,
-    end: Date,
-    externalId: string,
-    onboarded: Date,
-  ): Promise<number> {
-    this.logger.verbose(externalId);
-    if (new Date(onboarded).getTime() > new Date(end).getTime()) {
-      this.logger.verbose('The given dates are not for on-going reads');
-      return 0;
-    }
-    let fluxQuery = ``;
-    if (new Date(start).getTime() > new Date(onboarded).getTime()) {
-      fluxQuery = `from(bucket: "${process.env.INFLUXDB_BUCKET}")
-  |> range(start: ${start}, stop: ${end})
-  |> filter(fn: (r) => r._measurement == "read" and r.meter == "${externalId}")
-  |> count()`;
-    } else {
-      fluxQuery = `from(bucket: "${process.env.INFLUXDB_BUCKET}")
-  |> range(start: ${onboarded}, stop: ${end})
-  |> filter(fn: (r) => r._measurement == "read"and r.meter == "${externalId}")
-  |> count()`;
-    }
-    return await this.ongExecute(fluxQuery);
   }
 
   async ongExecute(query: string | any): Promise<number> {
@@ -1349,21 +1162,12 @@ export class ReadsService {
     return Number(data[0]._value);
   }
 
-  async latestRead(meterId: string, deviceOnboarded: Date): Promise<any> {
-    try {
-      const query = `
-        from(bucket: "${process.env.INFLUXDB_BUCKET}")
-        |> range(start: ${deviceOnboarded}, stop: now())
-        |> filter(fn: (r) => r.meter == "${meterId}" and r._field == "read")
-        |> last()
-        `;
-      return await this.execute(query);
-    } catch (error) {
-      this.logger.error(
-        `Error in influxdb query: ${error.message}`, //Please include the whole stack
-        error.stack,
-      );
-    }
+  async latestRead(meterId: string): Promise<any> {
+    return this.readsRepository
+      .createQueryBuilder('reads')
+      .where('reads.external_id = :meterId', { meterId })
+      .orderBy('reads.start_date', 'DESC')
+      .getOne();
   }
 
   async getAccumulatedReads(
@@ -1973,6 +1777,25 @@ export class ReadsService {
         message: `can not allow multiple reads simultaneously `,
       });
     }
-    return await this.storeRead(device.externalId, measurements);
+    await this.readsRepository.save({
+      externalId: device.externalId,
+      type: measurements.type,
+      value: measurements.reads[0].value,
+      unit: measurements.unit,
+      startDate: measurements.reads[0].starttimestamp,
+      endDate: measurements.reads[0].endtimestamp,
+      certified: false,
+    });
+  }
+  async getByExternalId(externalId: string, filter: FilterDTO): Promise<any> {
+    const query = this.readsRepository
+      .createQueryBuilder('reads')
+      .where('reads.external_id = :externalId', { externalId })
+      .andWhere('reads.start_date BETWEEN :start AND :end', {
+        start: new Date(filter.start),
+        end: new Date(filter.end),
+      });
+
+    return await query.getMany();
   }
 }


### PR DESCRIPTION
### Create a new Meter Reading Table

- A new table is created called meter-reads
- Create a new entity MeterRead inside the reads directory
- The logic to store and fetch meter reads should be updated to connect to this table
- The certificate issuance should be updated to reflect the new meter fetching using the new table
- Update the reads.services.ts and replace all meter reads storage to use the new MeterRead entity.
- Create a base branch from prod ft/migrate-from-influx-db that you will use as a target branch and your pr will merge into this one

#612 

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] No existing features have been broken without good reason.
- [x] The code style guideline have been followed
- [x] Documentation has been updated to reflect your changes.
