### PR TITLE
fix: avoid accidentally deleting a lock 

### DIFF
--- a/apps/drec-api/src/lib/cron.ts
+++ b/apps/drec-api/src/lib/cron.ts
@@ -1,6 +1,7 @@
 import { Cron, CronOptions } from '@nestjs/schedule';
 import { getRedisClient } from './redis';
 import { Logger } from '@nestjs/common';
+import { v4 as uuid4 } from 'uuid';
 
 // Lock expiration time in seconds
 const LOCK_TTL = 600;
@@ -21,6 +22,7 @@ const runExclusive = async <T>(
   const logger = new Logger(context);
 
   const key = `cron-lock:${context}:${functionName}`;
+  const lockId = uuid4(); // Generate unique lock value
 
   // Try to acquire the lock
   const isLocked = await redis.set(key, 'locked', 'EX', LOCK_TTL, 'NX');
@@ -33,8 +35,13 @@ const runExclusive = async <T>(
   try {
     return await fn();
   } finally {
-    // Lock will expire automatically after LOCK_TTL seconds
-    await redis.del(key);
+    // Ensure we only delete the lock if we still own it
+    const currentLockId = await redis.get(key);
+    if (currentLockId === lockId) {
+      await redis.del(key);
+    } else {
+      logger.warn(`${functionName}: Lock ownership lost, not deleting lock.`);
+    }
   }
 };
 

--- a/apps/drec-api/src/lib/cron.ts
+++ b/apps/drec-api/src/lib/cron.ts
@@ -25,7 +25,7 @@ const runExclusive = async <T>(
   const lockId = uuid4(); // Generate unique lock value
 
   // Try to acquire the lock
-  const isLocked = await redis.set(key, 'locked', 'EX', LOCK_TTL, 'NX');
+  const isLocked = await redis.set(key, lockId, 'EX', LOCK_TTL, 'NX');
 
   if (!isLocked) {
     logger.log(`${functionName}: Already running on another instance.`);
@@ -38,6 +38,8 @@ const runExclusive = async <T>(
     // Ensure we only delete the lock if we still own it
     const currentLockId = await redis.get(key);
     if (currentLockId === lockId) {
+      logger.log(`${functionName}: Lock released successfully.`);
+      // Delete the lock
       await redis.del(key);
     } else {
       logger.warn(`${functionName}: Lock ownership lost, not deleting lock.`);

--- a/apps/drec-api/src/pods/evident/evident-issuance.service.ts
+++ b/apps/drec-api/src/pods/evident/evident-issuance.service.ts
@@ -28,9 +28,11 @@ export class EvidentIssuanceService {
     private readonly evidentSettingsService: EvidentSettingsService,
   ) {}
 
-  @NonConcurrentCron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  // @NonConcurrentCron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  @NonConcurrentCron('*/15 * * * * *')
   async processIssuanceByFrequency(): Promise<void> {
     this.logger.verbose('Issuance request creation started');
+    console.log("hhhhhhhhhhhhhhhhhhhhhh started hhhhhhhhhhhhhhhhhh")
     const organizationsSettings =
       await this.evidentSettingsService.getAllOrganizationLastIssuanceSyncedAt();
 

--- a/apps/drec-api/src/pods/evident/evident-issuance.service.ts
+++ b/apps/drec-api/src/pods/evident/evident-issuance.service.ts
@@ -28,11 +28,9 @@ export class EvidentIssuanceService {
     private readonly evidentSettingsService: EvidentSettingsService,
   ) {}
 
-  // @NonConcurrentCron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
-  @NonConcurrentCron('*/15 * * * * *')
+  @NonConcurrentCron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async processIssuanceByFrequency(): Promise<void> {
     this.logger.verbose('Issuance request creation started');
-    console.log("hhhhhhhhhhhhhhhhhhhhhh started hhhhhhhhhhhhhhhhhh")
     const organizationsSettings =
       await this.evidentSettingsService.getAllOrganizationLastIssuanceSyncedAt();
 


### PR DESCRIPTION
### Describe your changes
This Pull Request is about refactoring a bit how we delete a lock in a queue for avoiding accidentally deleting another instance's lock.
### Issue ticket number and link

- [#25](https://github.com/orgs/d-rec/projects/2/views/8?pane=issue&itemId=118025449&issue=d-rec%7Cdrec-infrastructure%7C25)

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] No existing features have been broken without good reason.
- [x] The code style guideline have been followed
- [x] Documentation has been updated to reflect your changes.
