### PR TITLE
feat: Update other data sourece to developer externalId

### DIFF
--- a/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
+++ b/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable1755678370829
+export class UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable1755680751805
   implements MigrationInterface
 {
-  name = 'UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable1755678370829';
+  name = 'UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable1755680751805';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
@@ -16,7 +16,7 @@ export class UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable175567837082
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
             UPDATE device 
-            SET "other_data_source" = NULL
+            SET "other_data_source" = "developerExternalId"
             WHERE "developerExternalId" IS NULL 
         `);
   }

--- a/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
+++ b/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
@@ -9,7 +9,7 @@ export class UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable175568075180
     await queryRunner.query(`
             UPDATE device 
             SET "other_data_source" = "developerExternalId"
-            WHERE "developerExternalId" IS NOT NULL 
+            WHERE "developerExternalId" IS NOT NULL AND "developerExternalId" != ''
         `);
   }
 
@@ -17,7 +17,7 @@ export class UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable175568075180
     await queryRunner.query(`
             UPDATE device 
             SET "other_data_source" = "developerExternalId"
-            WHERE "developerExternalId" IS NULL 
+            WHERE "developerExternalId" IS NOT NULL AND "developerExternalId" != ''
         `);
   }
 }

--- a/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
+++ b/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable1755678370829
+  implements MigrationInterface
+{
+  name = 'UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable1755678370829';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            UPDATE device 
+            SET "other_data_source" = "developerExternalId"
+            WHERE "developerExternalId" IS NOT NULL 
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            UPDATE device 
+            SET "other_data_source" = NULL
+            WHERE "developerExternalId" IS NULL 
+        `);
+  }
+}

--- a/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
+++ b/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
@@ -8,7 +8,8 @@ export class UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable175568075180
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
             UPDATE device 
-            SET "other_data_source" = "developerExternalId"
+            SET "other_data_source" = "developerExternalId",
+            "data_source" = 'other'
             WHERE "developerExternalId" IS NOT NULL AND "developerExternalId" != ''
         `);
   }

--- a/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
+++ b/apps/drec-api/migrations/1755680751805-UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable.ts
@@ -17,7 +17,8 @@ export class UpdateOtherDataSourceToDeveloperExternalIdOnDeviceTable175568075180
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
             UPDATE device 
-            SET "other_data_source" = "developerExternalId"
+            SET "other_data_source" = null,
+            "data_source" = null
             WHERE "developerExternalId" IS NOT NULL AND "developerExternalId" != ''
         `);
   }


### PR DESCRIPTION
### Describe your changes

- Create a migration to update the other data source column in the device table to the developer externalId where the developer externalId is not null or empty.

### Issue ticket number and link

- #[212](https://github.com/orgs/d-rec/projects/2/views/8?pane=issue&itemId=123976576&issue=d-rec%7Cdrec-roadmap-internal%7C212)

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] No existing features have been broken without good reason.
- [x] The code style guideline have been followed
- [x] Documentation has been updated to reflect your changes.
