### PR TITLE
fix: normalize API timestamps to Z suffix

### DIFF
--- a/apps/drec-api/src/index.ts
+++ b/apps/drec-api/src/index.ts
@@ -4,6 +4,7 @@ import {
   ClassSerializerInterceptor,
 } from '@nestjs/common';
 import { Reflector, NestFactory } from '@nestjs/core';
+import { NormalizeDatesInterceptor } from './interceptors/normalize-dates.interceptor';
 import { SwaggerModule } from '@nestjs/swagger';
 import { useContainer } from 'class-validator';
 import fs from 'fs';
@@ -49,7 +50,10 @@ export async function startAPI(logger?: LoggerService): Promise<any> {
   });
 
   app.useGlobalPipes(new ValidationPipe({ forbidUnknownValues: false }));
-  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+  app.useGlobalInterceptors(
+    new ClassSerializerInterceptor(app.get(Reflector)),
+    new NormalizeDatesInterceptor(),
+  );
 
   app.enableShutdownHooks();
   app.enableCors({

--- a/apps/drec-api/src/interceptors/normalize-dates.interceptor.ts
+++ b/apps/drec-api/src/interceptors/normalize-dates.interceptor.ts
@@ -1,0 +1,37 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+const OFFSET_ZERO_RE = /\+00:00$/;
+
+function normalize(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'string' && OFFSET_ZERO_RE.test(value)) {
+    return value.replace(OFFSET_ZERO_RE, 'Z');
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalize);
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = normalize(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+@Injectable()
+export class NormalizeDatesInterceptor implements NestInterceptor {
+  intercept(_ctx: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(map(normalize));
+  }
+}

--- a/apps/drec-api/src/transformers/timezone.ts
+++ b/apps/drec-api/src/transformers/timezone.ts
@@ -25,5 +25,5 @@ export const toTimezoneDateFormat = (
 ): string | null => {
   if (!date) return null;
 
-  return momentTimeZone.tz(date, timezone).format();
+  return momentTimeZone.tz(date, timezone).toISOString();
 };


### PR DESCRIPTION
## Summary
- Adds a global `NormalizeDatesInterceptor` that ensures all API response timestamps use the `Z` (Zulu) suffix instead of `+00:00` offset notation
- Fixes `toTimezoneDateFormat` to use `.toISOString()` instead of `moment.format()`
- Resolves integration breakage reported by a partner whose parser expects `%Y-%m-%dT%H:%M:%S.%fZ`

## Test plan
- [ ] Deploy to staging and verify API responses use `Z` suffix timestamps
- [ ] Confirm partner integration no longer throws format mismatch errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)