### PR TITLE
fix: normalize API timestamps to Z suffix

### DIFF
--- a/apps/drec-api/src/index.ts
+++ b/apps/drec-api/src/index.ts
@@ -4,6 +4,7 @@ import {
   ClassSerializerInterceptor,
 } from '@nestjs/common';
 import { Reflector, NestFactory } from '@nestjs/core';
+import { NormalizeDatesInterceptor } from './interceptors/normalize-dates.interceptor';
 import { SwaggerModule } from '@nestjs/swagger';
 import { useContainer } from 'class-validator';
 import fs from 'fs';
@@ -45,7 +46,10 @@ export async function startAPI(logger?: LoggerService): Promise<any> {
   });
 
   app.useGlobalPipes(new ValidationPipe({ forbidUnknownValues: false }));
-  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+  app.useGlobalInterceptors(
+    new ClassSerializerInterceptor(app.get(Reflector)),
+    new NormalizeDatesInterceptor(),
+  );
 
   app.enableShutdownHooks();
   app.enableCors();

--- a/apps/drec-api/src/interceptors/normalize-dates.interceptor.ts
+++ b/apps/drec-api/src/interceptors/normalize-dates.interceptor.ts
@@ -1,0 +1,37 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+const OFFSET_ZERO_RE = /\+00:00$/;
+
+function normalize(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'string' && OFFSET_ZERO_RE.test(value)) {
+    return value.replace(OFFSET_ZERO_RE, 'Z');
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalize);
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = normalize(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+@Injectable()
+export class NormalizeDatesInterceptor implements NestInterceptor {
+  intercept(_ctx: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(map(normalize));
+  }
+}

--- a/apps/drec-api/src/transformers/timezone.ts
+++ b/apps/drec-api/src/transformers/timezone.ts
@@ -25,5 +25,5 @@ export const toTimezoneDateFormat = (
 ): string | null => {
   if (!date) return null;
 
-  return momentTimeZone.tz(date, timezone).format();
+  return momentTimeZone.tz(date, timezone).toISOString();
 };

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,8 +3,8 @@ import { h } from 'vue';
 import DefaultTheme from 'vitepress/theme';
 import './custom.css';
 
-import { YouTubeEmbed } from '@miletorix/vitepress-youtube-embed'
-import '@miletorix/vitepress-youtube-embed/style.css'
+import { YouTubeEmbed } from '@miletorix/vitepress-youtube-embed';
+import '@miletorix/vitepress-youtube-embed/style.css';
 
 /** @type {import('vitepress').Theme} */
 export default {
@@ -15,6 +15,6 @@ export default {
     });
   },
   enhanceApp({ app, router, siteData }) {
-    app.component('YouTubeEmbed', YouTubeEmbed)
+    app.component('YouTubeEmbed', YouTubeEmbed);
   },
 };


### PR DESCRIPTION
## Summary
- Cherry-pick of f36ebc7b from develop
- Adds `NormalizeDatesInterceptor` that converts `+00:00` → `Z` and `Date` objects → ISO strings in all API responses
- Fixes customer-reported issue where `commissioning_date` in `devices/my` changed format from `Z` to `+00:00`, breaking their parser

## Context
DB data has already been patched (501 rows normalized). This interceptor ensures all future API responses are consistent regardless of how dates are stored.

## Test plan
- [ ] Verify `devices/my` returns `commissioningDate` ending in `Z`
- [ ] Verify no other date fields regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)