### PR TITLE
solar-yield: TS port of Kartik's prediction model + wire into production-ceiling

### DIFF
--- a/apps/drec-api/src/drec.module.ts
+++ b/apps/drec-api/src/drec.module.ts
@@ -86,6 +86,7 @@ import { DeviceReviewsModule } from './pods/device-reviews/device-reviews.module
 import { UploadLogModule } from './pods/upload-log/upload-log.module';
 import { ESignatureModule } from './pods/e-signature/e-signature.module';
 import { OrgApiLicensesModule } from './pods/org-api-licenses/org-api-licenses.module';
+import { SolarYieldModule } from './pods/solar-yield/solar-yield.module';
 import { OrgApiLicenses } from './pods/org-api-licenses/org-api-licenses.entity';
 import { UploadLogEntity } from './pods/upload-log/upload-log.entity';
 import { ESignatureLog } from './pods/e-signature/e-signature-log.entity';
@@ -216,6 +217,7 @@ const queueModule = () => {
     UploadLogModule,
     ESignatureModule,
     OrgApiLicensesModule,
+    SolarYieldModule,
   ],
   providers: [
     OnApplicationBootstrapHookService,

--- a/apps/drec-api/src/pods/device-reviews/device-reviews.module.ts
+++ b/apps/drec-api/src/pods/device-reviews/device-reviews.module.ts
@@ -6,6 +6,7 @@ import { FileModule } from '../file/file.module';
 import { UserModule } from '../user/user.module';
 import { DocumentUploadsModule } from '../document-uploads/document-uploads.module';
 import { OrgApiLicensesModule } from '../org-api-licenses/org-api-licenses.module';
+import { SolarYieldModule } from '../solar-yield/solar-yield.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { OrgApiLicensesModule } from '../org-api-licenses/org-api-licenses.modul
     DocumentUploadsModule,
     forwardRef(() => UserModule),
     OrgApiLicensesModule,
+    SolarYieldModule,
   ],
   controllers: [DeviceReviewsController],
   providers: [DeviceReviewsService],

--- a/apps/drec-api/src/pods/device-reviews/device-reviews.service.ts
+++ b/apps/drec-api/src/pods/device-reviews/device-reviews.service.ts
@@ -1065,7 +1065,9 @@ export class DeviceReviewsService {
     irradiance: IrradianceEstimate | null;
     /** Solar GSA climatology estimate (more accurate than the lat-band
      * fallback in `irradiance`). Null when the grid isn't provisioned
-     * (`SOLAR_GRID_NPZ_PATH` unset) or inputs are out of range. */
+     * (`SOLAR_GRID_NPZ_PATH` unset), the device is pre-COD, the device is
+     * missing lat/lon/capacity/COD, or its coordinates are outside the
+     * grid's lat ∈ [-60, 65] / lon ∈ [-180, 180] coverage. */
     solarGsa: {
       annualKwh: number;
       monthlyKwh: number[];

--- a/apps/drec-api/src/pods/device-reviews/device-reviews.service.ts
+++ b/apps/drec-api/src/pods/device-reviews/device-reviews.service.ts
@@ -20,6 +20,7 @@ import {
   estimateIrradiance,
   IrradianceEstimate,
 } from '../../utils/irradiance-estimate';
+import { SolarYieldService } from '../solar-yield/solar-yield.service';
 import {
   requiresCompensatingControls,
   CompensatingControlResult,
@@ -91,6 +92,7 @@ export class DeviceReviewsService {
   constructor(
     @InjectDataSource() private readonly connection: DataSource,
     private readonly fileService: FileService,
+    private readonly solarYield: SolarYieldService,
   ) {}
 
   /**
@@ -1061,6 +1063,14 @@ export class DeviceReviewsService {
    */
   async checkProductionCeiling(deviceId: number): Promise<{
     irradiance: IrradianceEstimate | null;
+    /** Solar GSA climatology estimate (more accurate than the lat-band
+     * fallback in `irradiance`). Null when the grid isn't provisioned
+     * (`SOLAR_GRID_NPZ_PATH` unset) or inputs are out of range. */
+    solarGsa: {
+      annualKwh: number;
+      monthlyKwh: number[];
+      version: string;
+    } | null;
     configuredYield: number;
     capacityKw: number;
     yieldMismatch: boolean;
@@ -1098,6 +1108,54 @@ export class DeviceReviewsService {
       // with a 10% tolerance
       if (configuredYield !== null) {
         yieldMismatch = configuredYield > irradiance.yieldHigh * 1.1;
+      }
+    }
+
+    // Solar GSA climatology — typical-year per-month estimate. Additive to
+    // the lat-band `irradiance` above; when present, reviewers should prefer
+    // this for monthly comparisons. Unavailable if the grid file isn't
+    // provisioned or the site falls outside the grid.
+    let solarGsa: {
+      annualKwh: number;
+      monthlyKwh: number[];
+      version: string;
+    } | null = null;
+    if (
+      lat !== null &&
+      lng !== null &&
+      !isNaN(lat) &&
+      !isNaN(lng) &&
+      capacityKw > 0 &&
+      device.commissioningDate
+    ) {
+      try {
+        const currentYear = new Date().getUTCFullYear();
+        const codYear = new Date(device.commissioningDate).getUTCFullYear();
+        // Post-COD only; pre-COD would throw from the service guard and we
+        // already know the device's own history is empty there.
+        if (!isNaN(codYear) && currentYear >= codYear) {
+          const res = this.solarYield.getSolarEnergy(
+            lat,
+            lng,
+            capacityKw,
+            device.commissioningDate,
+            currentYear,
+          );
+          const monthly = res.Model_1_Outputs.Monthly_kWh;
+          // Case B (year == COD year) returns a padded vector with zeros
+          // before the COD month; that's fine to surface as-is.
+          if (monthly.length === 12) {
+            solarGsa = {
+              annualKwh: res.Model_1_Outputs.Yield_kWh,
+              monthlyKwh: monthly,
+              version: res.Model_1_Outputs.Version,
+            };
+          }
+        }
+      } catch (e: any) {
+        this.logger.debug(
+          `solarGsa unavailable for device ${deviceId}: ${e?.message || e}`,
+        );
       }
     }
 
@@ -1158,6 +1216,7 @@ export class DeviceReviewsService {
 
     return {
       irradiance,
+      solarGsa,
       configuredYield,
       capacityKw,
       yieldMismatch,

--- a/apps/drec-api/src/pods/device-reviews/device-reviews.service.ts
+++ b/apps/drec-api/src/pods/device-reviews/device-reviews.service.ts
@@ -1,11 +1,21 @@
-import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import * as exifr from 'exifr';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const PDFDocument = require('pdfkit');
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { FileService } from '../file/file.service';
-import { EvidencePathway, OperatingConfiguration, OwnershipStatus, SourceAccessMode } from '../../utils/enums';
+import {
+  EvidencePathway,
+  OperatingConfiguration,
+  OwnershipStatus,
+  SourceAccessMode,
+} from '../../utils/enums';
 import {
   getSourceAccessVerification,
   ModeVerificationRule,
@@ -151,21 +161,29 @@ export class DeviceReviewsService {
     await this.connection.query(
       `INSERT INTO audit_log (device_id, action_type, detail, performed_by, metadata)
        VALUES ($1, $2, $3, $4, $5)`,
-      [deviceId, actionType, detail, performedBy, Object.keys(meta).length > 0 ? JSON.stringify(meta) : null],
+      [
+        deviceId,
+        actionType,
+        detail,
+        performedBy,
+        Object.keys(meta).length > 0 ? JSON.stringify(meta) : null,
+      ],
     );
   }
 
   /**
    * D-REC §3.8: Retrieve the full audit trail for a device.
    */
-  async getAuditTrail(deviceId: number): Promise<Array<{
-    id: number;
-    actionType: string;
-    detail: string | null;
-    performedBy: string;
-    metadata: Record<string, any> | null;
-    createdAt: Date;
-  }>> {
+  async getAuditTrail(deviceId: number): Promise<
+    Array<{
+      id: number;
+      actionType: string;
+      detail: string | null;
+      performedBy: string;
+      metadata: Record<string, any> | null;
+      createdAt: Date;
+    }>
+  > {
     return this.connection.query(
       `SELECT id, action_type AS "actionType", detail, performed_by AS "performedBy",
               metadata, created_at AS "createdAt"
@@ -198,7 +216,14 @@ export class DeviceReviewsService {
       this.logger.log(
         `Device ${deviceId} review status changed to "${status}"`,
       );
-      await this.logAudit(deviceId, 'status_change', `Status changed to "${status}"`, 'reviewer', undefined, ipAddress);
+      await this.logAudit(
+        deviceId,
+        'status_change',
+        `Status changed to "${status}"`,
+        'reviewer',
+        undefined,
+        ipAddress,
+      );
       // D-REC §3.1: Classify evidence pathway
       // D-REC §2.7: Verify ownership on approval
       if (status === 'approved') {
@@ -208,7 +233,9 @@ export class DeviceReviewsService {
       // Auto-screen when entering pending — fire-and-forget
       if (status === 'pending') {
         this.autoScreenReport(deviceId).catch((err) =>
-          this.logger.warn(`Auto-screen on submission failed for device ${deviceId}: ${err.message}`),
+          this.logger.warn(
+            `Auto-screen on submission failed for device ${deviceId}: ${err.message}`,
+          ),
         );
       }
       return { status: rows[0].status };
@@ -234,7 +261,9 @@ export class DeviceReviewsService {
     );
     if (status === 'pending') {
       this.autoScreenReport(deviceId).catch((err) =>
-        this.logger.warn(`Auto-screen on submission failed for device ${deviceId}: ${err.message}`),
+        this.logger.warn(
+          `Auto-screen on submission failed for device ${deviceId}: ${err.message}`,
+        ),
       );
     }
     return { status };
@@ -327,7 +356,9 @@ export class DeviceReviewsService {
     roboflowKey?: string,
   ): Promise<any> {
     if (!roboflowUrl || !roboflowKey) {
-      throw new Error('Roboflow URL and API key must be provided — configure them in Organization > Licenses');
+      throw new Error(
+        'Roboflow URL and API key must be provided — configure them in Organization > Licenses',
+      );
     }
     let res: Response;
     try {
@@ -352,7 +383,9 @@ export class DeviceReviewsService {
     }
     if (!res.ok) {
       const body = await res.text().catch(() => '');
-      throw new Error(`Roboflow API returned ${res.status}: ${body.slice(0, 200)}`);
+      throw new Error(
+        `Roboflow API returned ${res.status}: ${body.slice(0, 200)}`,
+      );
     }
     return res.json();
   }
@@ -448,7 +481,7 @@ export class DeviceReviewsService {
       const devDocs: any[] = docsByDevice[String(r.id)] ?? [];
       const byType = (t: string) => {
         const doc = devDocs.find((d) => d.type === t);
-        return doc ? (signedUrls[doc.url] ?? null) : null;
+        return doc ? signedUrls[doc.url] ?? null : null;
       };
       const allOfType = (t: string) =>
         devDocs
@@ -515,7 +548,8 @@ export class DeviceReviewsService {
           r.siteName &&
           (r.serialNumber || r.externalId) &&
           r.countryCode &&
-          r.latitude && r.longitude &&
+          r.latitude &&
+          r.longitude &&
           r.address &&
           r.capacity != null &&
           r.fuelCode &&
@@ -631,9 +665,13 @@ export class DeviceReviewsService {
       });
     }
 
-    await this.logAudit(deviceId, 'duplicate_screening',
+    await this.logAudit(
+      deviceId,
+      'duplicate_screening',
       `${duplicates.length} potential duplicate(s) found`,
-      'reviewer', { duplicateCount: duplicates.length });
+      'reviewer',
+      { duplicateCount: duplicates.length },
+    );
 
     return { duplicates };
   }
@@ -664,7 +702,7 @@ export class DeviceReviewsService {
     }
     // Owner's Declaration / Proof of Ownership is always required
     if (!existingTypes.has('SF_02C_OWNERS_DECLARATION')) {
-      missingDocuments.push('Owner\'s Declaration / Proof of Ownership');
+      missingDocuments.push("Owner's Declaration / Proof of Ownership");
     }
     // SF-02 (Production Facility Registration) is always required
     if (!existingTypes.has('FORM_SF_02')) {
@@ -687,9 +725,13 @@ export class DeviceReviewsService {
           ? ` (missing: ${missingDocuments.join(', ')})`
           : ''),
     );
-    await this.logAudit(deviceId, 'ownership_verification',
+    await this.logAudit(
+      deviceId,
+      'ownership_verification',
       `Ownership ${ownershipStatus}${missingDocuments.length ? ': missing ' + missingDocuments.join(', ') : ''}`,
-      'system', { ownershipStatus, missingDocuments });
+      'system',
+      { ownershipStatus, missingDocuments },
+    );
 
     return { ownershipStatus, missingDocuments };
   }
@@ -741,9 +783,13 @@ export class DeviceReviewsService {
       `Device ${deviceId} classified as: ${pathway ?? 'unclassified'} ` +
         `(config=${operatingConfiguration}, mode=${sourceAccessMode})`,
     );
-    await this.logAudit(deviceId, 'pathway_classification',
+    await this.logAudit(
+      deviceId,
+      'pathway_classification',
       `Classified as: ${pathway ?? 'unclassified'}`,
-      'system', { pathway, operatingConfiguration, sourceAccessMode });
+      'system',
+      { pathway, operatingConfiguration, sourceAccessMode },
+    );
 
     return { evidencePathway: pathway, requirements };
   }
@@ -792,7 +838,7 @@ export class DeviceReviewsService {
     const docLabel: Record<string, string> = {
       FORM_SF_02: 'SF-02 (Production Facility Registration)',
       SF_02C: 'SF-02C (I-REC declaration form)',
-      SF_02C_OWNERS_DECLARATION: 'Owner\'s Declaration / Proof of Ownership',
+      SF_02C_OWNERS_DECLARATION: "Owner's Declaration / Proof of Ownership",
       METERING_EVIDENCE: 'Metering Evidence',
       SINGLE_LINE_DIAGRAM: 'Single Line Diagram',
       PROJECT_PHOTOS: 'Project Photos',
@@ -946,20 +992,13 @@ export class DeviceReviewsService {
         if (zeroStart === -1) zeroStart = i;
       } else {
         if (zeroStart !== -1 && i - zeroStart >= 3) {
-          zeroRuns.push(
-            normalized.slice(zeroStart, i).map((r) => r.id),
-          );
+          zeroRuns.push(normalized.slice(zeroStart, i).map((r) => r.id));
         }
         zeroStart = -1;
       }
     }
-    if (
-      zeroStart !== -1 &&
-      normalized.length - zeroStart >= 3
-    ) {
-      zeroRuns.push(
-        normalized.slice(zeroStart).map((r) => r.id),
-      );
+    if (zeroStart !== -1 && normalized.length - zeroStart >= 3) {
+      zeroRuns.push(normalized.slice(zeroStart).map((r) => r.id));
     }
     for (const run of zeroRuns) {
       anomalies.push({
@@ -975,8 +1014,7 @@ export class DeviceReviewsService {
     if (normalized.length > windowSize) {
       for (let i = windowSize; i < normalized.length; i++) {
         const window = normalized.slice(i - windowSize, i);
-        const avg =
-          window.reduce((s, r) => s + r.kwh, 0) / windowSize;
+        const avg = window.reduce((s, r) => s + r.kwh, 0) / windowSize;
         if (avg > 0 && normalized[i].kwh > avg * 3) {
           anomalies.push({
             type: 'spike',
@@ -1043,9 +1081,13 @@ export class DeviceReviewsService {
         `${periodMonths} months, ${anomalies.length} anomalies`,
     );
 
-    await this.logAudit(deviceId, 'historical_consistency',
+    await this.logAudit(
+      deviceId,
+      'historical_consistency',
       `${reads.length} readings, ${anomalies.length} anomalies over ${periodMonths} months`,
-      'reviewer', { totalReadings: reads.length, anomalyCount: anomalies.length });
+      'reviewer',
+      { totalReadings: reads.length, anomalyCount: anomalies.length },
+    );
 
     return {
       totalReadings: reads.length,
@@ -1099,7 +1141,9 @@ export class DeviceReviewsService {
     const lat = device.latitude ? parseFloat(device.latitude) : null;
     const lng = device.longitude ? parseFloat(device.longitude) : null;
     const capacityKw = device.capacity ? parseFloat(device.capacity) : 0;
-    const configuredYield = device.yieldValue ? parseFloat(device.yieldValue) : null;
+    const configuredYield = device.yieldValue
+      ? parseFloat(device.yieldValue)
+      : null;
 
     // Estimate irradiance from location
     let irradiance: IrradianceEstimate | null = null;
@@ -1184,8 +1228,7 @@ export class DeviceReviewsService {
       else if (r.unit === 'GWh') valueKwh *= 1000000;
 
       // Ceiling for this period: capacity × hourly yield rate × period × 1.2 margin
-      const ceilingKwh =
-        capacityKw * (ceilingYield / 8760) * periodHours * 1.2;
+      const ceilingKwh = capacityKw * (ceilingYield / 8760) * periodHours * 1.2;
 
       return {
         startDate: r.startDate,
@@ -1208,13 +1251,25 @@ export class DeviceReviewsService {
     if (configuredYield === null) {
       parts.push('No yield value configured on device');
     } else if (yieldMismatch) {
-      parts.push(`Configured yield ${configuredYield} exceeds location estimate ${irradiance?.yieldHigh} kWh/kW/yr`);
+      parts.push(
+        `Configured yield ${configuredYield} exceeds location estimate ${irradiance?.yieldHigh} kWh/kW/yr`,
+      );
     } else {
-      parts.push(`Configured yield ${configuredYield} is within expected range for location`);
+      parts.push(
+        `Configured yield ${configuredYield} is within expected range for location`,
+      );
     }
-    await this.logAudit(deviceId, 'ceiling_check',
+    await this.logAudit(
+      deviceId,
+      'ceiling_check',
       parts.join('. '),
-      'reviewer', { configuredYield, irradianceYield: irradiance?.yieldHigh, yieldMismatch });
+      'reviewer',
+      {
+        configuredYield,
+        irradianceYield: irradiance?.yieldHigh,
+        yieldMismatch,
+      },
+    );
 
     return {
       irradiance,
@@ -1259,15 +1314,22 @@ export class DeviceReviewsService {
       [deviceId],
     );
     const existingTypes = new Set(docs.map((d) => d.type));
-    const mode4Required = ['METERING_EVIDENCE', 'FORM_SF_02', 'SF_02C', 'SF_02C_OWNERS_DECLARATION', 'COD_PROOF'];
+    const mode4Required = [
+      'METERING_EVIDENCE',
+      'FORM_SF_02',
+      'SF_02C',
+      'SF_02C_OWNERS_DECLARATION',
+      'COD_PROOF',
+    ];
     const missingDocs = mode4Required.filter((t) => !existingTypes.has(t));
     controls.push({
       id: 'required_documents',
       label: 'All required documents uploaded',
       satisfied: missingDocs.length === 0,
-      detail: missingDocs.length === 0
-        ? 'All 5 required document types are present'
-        : `Missing: ${missingDocs.join(', ')}`,
+      detail:
+        missingDocs.length === 0
+          ? 'All 5 required document types are present'
+          : `Missing: ${missingDocs.join(', ')}`,
     });
 
     // Control 2: COD / third-party attestation specifically verified
@@ -1341,18 +1403,28 @@ export class DeviceReviewsService {
       id: 'ownership_verified',
       label: 'Ownership verification complete',
       satisfied: ownershipStatus === 'verified',
-      detail: ownershipStatus === 'verified'
-        ? 'Device ownership has been verified'
-        : `Ownership status is "${ownershipStatus || 'unverified'}"`,
+      detail:
+        ownershipStatus === 'verified'
+          ? 'Device ownership has been verified'
+          : `Ownership status is "${ownershipStatus || 'unverified'}"`,
     });
 
     const allSatisfied = controls.every((c) => c.satisfied);
 
-    await this.logAudit(deviceId, 'compensating_controls',
+    await this.logAudit(
+      deviceId,
+      'compensating_controls',
       `Mode 4 evaluation: ${allSatisfied ? 'all satisfied' : controls.filter((c) => !c.satisfied).length + ' control(s) failed'}`,
-      'system', { controls: controls.map((c) => ({ id: c.id, satisfied: c.satisfied })) });
+      'system',
+      { controls: controls.map((c) => ({ id: c.id, satisfied: c.satisfied })) },
+    );
 
-    return { isMode4: true, allSatisfied, controls, ...(pathwayNote ? { pathwayNote } : {}) };
+    return {
+      isMode4: true,
+      allSatisfied,
+      controls,
+      ...(pathwayNote ? { pathwayNote } : {}),
+    };
   }
 
   /**
@@ -1361,7 +1433,9 @@ export class DeviceReviewsService {
    * Compares actual meter readings against irradiance-modeled monthly
    * production, computing a regression-based Performance Factor.
    */
-  async crossSourceVerification(deviceId: number): Promise<CrossSourceResult & { pathwayNote?: string }> {
+  async crossSourceVerification(
+    deviceId: number,
+  ): Promise<CrossSourceResult & { pathwayNote?: string }> {
     const pathwayNote = await this.ensurePathwayClassified(deviceId);
     // Fetch device
     const rows: any[] = await this.connection.query(
@@ -1517,7 +1591,8 @@ export class DeviceReviewsService {
   }
 
   async findMeterReadsForDevice(deviceId: number): Promise<any[]> {
-    const rows = await this.connection.query(`
+    const rows = await this.connection.query(
+      `
       SELECT mr.id, mr.value, mr.unit, mr.type,
              mr.start_date AS "startDate",
              mr.end_date   AS "endDate",
@@ -1526,7 +1601,9 @@ export class DeviceReviewsService {
       INNER JOIN device d ON d."externalId" = mr.external_id
       WHERE d.id = $1
       ORDER BY mr.end_date DESC
-    `, [deviceId]);
+    `,
+      [deviceId],
+    );
     return rows;
   }
 
@@ -1565,23 +1642,36 @@ export class DeviceReviewsService {
     reviewer?: string,
     ip?: string,
   ): Promise<Array<{ deviceId: number; status: string; error?: string }>> {
-    const results: Array<{ deviceId: number; status: string; error?: string }> = [];
+    const results: Array<{ deviceId: number; status: string; error?: string }> =
+      [];
     for (const id of deviceIds) {
       try {
-        const res = await this.updateMeterReadReviewStatus(id, status, undefined, reviewer, ip);
+        const res = await this.updateMeterReadReviewStatus(
+          id,
+          status,
+          undefined,
+          reviewer,
+          ip,
+        );
         results.push({ deviceId: id, status: res.status });
       } catch (err: any) {
         results.push({ deviceId: id, status: 'error', error: err.message });
       }
     }
-    const succeeded = results.filter((r) => r.status !== 'error').map((r) => r.deviceId);
+    const succeeded = results
+      .filter((r) => r.status !== 'error')
+      .map((r) => r.deviceId);
     for (const id of succeeded) {
       await this.logAudit(
         id,
         'bulk_status_change',
         `Bulk meter-read review status change to "${status}" (${deviceIds.length} devices in batch)`,
         reviewer || 'reviewer',
-        { batchSize: deviceIds.length, targetStatus: status, context: 'meter_reads' },
+        {
+          batchSize: deviceIds.length,
+          targetStatus: status,
+          context: 'meter_reads',
+        },
         ip,
       );
     }
@@ -1645,7 +1735,14 @@ export class DeviceReviewsService {
     );
 
     if (!rows.length) {
-      return { totalReads: 0, gaps: [], coveragePercent: 0, firstRead: null, lastRead: null, expectedPeriodDays: null };
+      return {
+        totalReads: 0,
+        gaps: [],
+        coveragePercent: 0,
+        firstRead: null,
+        lastRead: null,
+        expectedPeriodDays: null,
+      };
     }
 
     // Estimate expected period from median gap between consecutive reads
@@ -1656,15 +1753,18 @@ export class DeviceReviewsService {
       intervals.push((curr - prev) / (1000 * 60 * 60 * 24));
     }
     intervals.sort((a, b) => a - b);
-    const medianDays = intervals.length > 0 ? intervals[Math.floor(intervals.length / 2)] : null;
+    const medianDays =
+      intervals.length > 0 ? intervals[Math.floor(intervals.length / 2)] : null;
     // A gap is anything > 2x the median interval (or > 45 days if < 3 reads)
-    const threshold = medianDays !== null && intervals.length >= 3 ? medianDays * 2 : 45;
+    const threshold =
+      medianDays !== null && intervals.length >= 3 ? medianDays * 2 : 45;
 
     const gaps: Array<{ after: string; before: string; gapDays: number }> = [];
     for (let i = 1; i < rows.length; i++) {
       const prevEnd = new Date(rows[i - 1].end_date);
       const currStart = new Date(rows[i].start_date);
-      const gapDays = (currStart.getTime() - prevEnd.getTime()) / (1000 * 60 * 60 * 24);
+      const gapDays =
+        (currStart.getTime() - prevEnd.getTime()) / (1000 * 60 * 60 * 24);
       if (gapDays > threshold) {
         gaps.push({
           after: rows[i - 1].end_date,
@@ -1678,9 +1778,14 @@ export class DeviceReviewsService {
     const lastDate = new Date(rows[rows.length - 1].end_date).getTime();
     const totalSpanDays = (lastDate - firstDate) / (1000 * 60 * 60 * 24);
     const coveredDays = rows.reduce((sum: number, r: any) => {
-      return sum + (new Date(r.end_date).getTime() - new Date(r.start_date).getTime()) / (1000 * 60 * 60 * 24);
+      return (
+        sum +
+        (new Date(r.end_date).getTime() - new Date(r.start_date).getTime()) /
+          (1000 * 60 * 60 * 24)
+      );
     }, 0);
-    const coveragePercent = totalSpanDays > 0 ? Math.round((coveredDays / totalSpanDays) * 100) : 100;
+    const coveragePercent =
+      totalSpanDays > 0 ? Math.round((coveredDays / totalSpanDays) * 100) : 100;
 
     await this.logAudit(
       deviceId,
@@ -1726,7 +1831,8 @@ export class DeviceReviewsService {
         signal: controller.signal,
         headers: {
           // Nominatim TOS requires a meaningful User-Agent identifying the app.
-          'User-Agent': 'drec-api country-match verification (https://d-rec.org)',
+          'User-Agent':
+            'drec-api country-match verification (https://d-rec.org)',
           Accept: 'application/json',
         },
       });
@@ -1764,7 +1870,8 @@ export class DeviceReviewsService {
       throw new NotFoundException(`Device ${deviceId} not found`);
     }
     const lat = rows[0].latitude != null ? parseFloat(rows[0].latitude) : null;
-    const lng = rows[0].longitude != null ? parseFloat(rows[0].longitude) : null;
+    const lng =
+      rows[0].longitude != null ? parseFloat(rows[0].longitude) : null;
     const declaredCountry: string | null = rows[0].countryCode ?? null;
 
     let resolvedAlpha2: string | null | undefined;
@@ -1800,7 +1907,12 @@ export class DeviceReviewsService {
       withinThreshold: boolean | null;
     }>;
     thresholdMeters: number;
-    summary: { total: number; withGps: number; withinThreshold: number; flagged: number };
+    summary: {
+      total: number;
+      withGps: number;
+      withinThreshold: number;
+      flagged: number;
+    };
   }> {
     const THRESHOLD_M = 300;
 
@@ -1812,11 +1924,21 @@ export class DeviceReviewsService {
     if (deviceRows.length === 0) {
       throw new NotFoundException(`Device ${deviceId} not found`);
     }
-    const deviceLat = deviceRows[0].latitude != null ? parseFloat(deviceRows[0].latitude) : null;
-    const deviceLng = deviceRows[0].longitude != null ? parseFloat(deviceRows[0].longitude) : null;
+    const deviceLat =
+      deviceRows[0].latitude != null
+        ? parseFloat(deviceRows[0].latitude)
+        : null;
+    const deviceLng =
+      deviceRows[0].longitude != null
+        ? parseFloat(deviceRows[0].longitude)
+        : null;
 
     // Get PROJECT_PHOTOS documents
-    const docs: Array<{ id: number; url: string; original_filename: string | null }> = await this.connection.query(
+    const docs: Array<{
+      id: number;
+      url: string;
+      original_filename: string | null;
+    }> = await this.connection.query(
       `SELECT id, url, original_filename FROM documents
        WHERE target_id = $1 AND target_type = 'device' AND type = 'PROJECT_PHOTOS'`,
       [deviceId],
@@ -1845,20 +1967,38 @@ export class DeviceReviewsService {
         const s3Result = await this.fileService.getUploadS3(doc.url);
         const buffer: Buffer = s3Result.data?.Body;
         if (!buffer) {
-          photos.push({ docId: doc.id, fileName, hasGps: false, lat: null, lng: null, distanceMeters: null, withinThreshold: null });
+          photos.push({
+            docId: doc.id,
+            fileName,
+            hasGps: false,
+            lat: null,
+            lng: null,
+            distanceMeters: null,
+            withinThreshold: null,
+          });
           continue;
         }
 
         const gps = await exifr.gps(buffer).catch(() => null);
         if (!gps || gps.latitude == null || gps.longitude == null) {
-          photos.push({ docId: doc.id, fileName, hasGps: false, lat: null, lng: null, distanceMeters: null, withinThreshold: null });
+          photos.push({
+            docId: doc.id,
+            fileName,
+            hasGps: false,
+            lat: null,
+            lng: null,
+            distanceMeters: null,
+            withinThreshold: null,
+          });
           continue;
         }
 
         let distanceMeters: number | null = null;
         let withinThreshold: boolean | null = null;
         if (deviceLat != null && deviceLng != null) {
-          distanceMeters = Math.round(haversineMeters(deviceLat, deviceLng, gps.latitude, gps.longitude));
+          distanceMeters = Math.round(
+            haversineMeters(deviceLat, deviceLng, gps.latitude, gps.longitude),
+          );
           withinThreshold = distanceMeters <= THRESHOLD_M;
         }
 
@@ -1872,8 +2012,18 @@ export class DeviceReviewsService {
           withinThreshold,
         });
       } catch (err) {
-        this.logger.warn(`EXIF extraction failed for doc ${doc.id}: ${err.message}`);
-        photos.push({ docId: doc.id, fileName, hasGps: false, lat: null, lng: null, distanceMeters: null, withinThreshold: null });
+        this.logger.warn(
+          `EXIF extraction failed for doc ${doc.id}: ${err.message}`,
+        );
+        photos.push({
+          docId: doc.id,
+          fileName,
+          hasGps: false,
+          lat: null,
+          lng: null,
+          distanceMeters: null,
+          withinThreshold: null,
+        });
       }
     }
 
@@ -1881,16 +2031,31 @@ export class DeviceReviewsService {
     const withinCount = photos.filter((p) => p.withinThreshold === true).length;
     const flagged = photos.filter((p) => p.withinThreshold === false).length;
 
-    await this.logAudit(deviceId, 'photo_gps_check',
+    await this.logAudit(
+      deviceId,
+      'photo_gps_check',
       `${photos.length} photos: ${withGps} with GPS, ${withinCount} within ${THRESHOLD_M}m, ${flagged} flagged`,
-      'reviewer', { thresholdMeters: THRESHOLD_M, total: photos.length, withGps, withinCount, flagged });
+      'reviewer',
+      {
+        thresholdMeters: THRESHOLD_M,
+        total: photos.length,
+        withGps,
+        withinCount,
+        flagged,
+      },
+    );
 
     return {
       deviceLat,
       deviceLng,
       photos,
       thresholdMeters: THRESHOLD_M,
-      summary: { total: photos.length, withGps, withinThreshold: withinCount, flagged },
+      summary: {
+        total: photos.length,
+        withGps,
+        withinThreshold: withinCount,
+        flagged,
+      },
     };
   }
 
@@ -1951,11 +2116,22 @@ export class DeviceReviewsService {
         flags.push(`Missing: ${r.missingDocuments.join(', ')}`);
       sections.push({
         name: 'Ownership Verification',
-        status: r.missingDocuments?.length > 0 ? 'fail' : flags.length === 0 ? 'pass' : 'warn',
+        status:
+          r.missingDocuments?.length > 0
+            ? 'fail'
+            : flags.length === 0
+              ? 'pass'
+              : 'warn',
         flags,
       });
     } else {
-      sections.push({ name: 'Ownership Verification', status: 'skip', flags: [`Check failed: ${ownership.reason?.message || ownership.reason || 'unknown error'}`] });
+      sections.push({
+        name: 'Ownership Verification',
+        status: 'skip',
+        flags: [
+          `Check failed: ${ownership.reason?.message || ownership.reason || 'unknown error'}`,
+        ],
+      });
     }
 
     // 2. Duplicates
@@ -1966,7 +2142,9 @@ export class DeviceReviewsService {
       if (dups.length > 0) {
         flags.push(`${dups.length} potential duplicate(s) found`);
         for (const d of dups.slice(0, 5)) {
-          flags.push(`  → ${d.siteName || d.externalId || `ID ${d.id}`} (${d.matchType}, org #${d.organizationId})`);
+          flags.push(
+            `  → ${d.siteName || d.externalId || `ID ${d.id}`} (${d.matchType}, org #${d.organizationId})`,
+          );
         }
         if (dups.length > 5) flags.push(`  … and ${dups.length - 5} more`);
       }
@@ -1976,7 +2154,13 @@ export class DeviceReviewsService {
         flags,
       });
     } else {
-      sections.push({ name: 'Duplicate Screening', status: 'skip', flags: [`Check failed: ${duplicates.reason?.message || duplicates.reason || 'unknown error'}`] });
+      sections.push({
+        name: 'Duplicate Screening',
+        status: 'skip',
+        flags: [
+          `Check failed: ${duplicates.reason?.message || duplicates.reason || 'unknown error'}`,
+        ],
+      });
     }
 
     // 3. Source Access
@@ -1991,18 +2175,32 @@ export class DeviceReviewsService {
       if (r.missingRequired?.length > 0)
         flags.push(`Missing required docs: ${r.missingRequired.join(', ')}`);
       if (r.missingRecommended?.length > 0)
-        flags.push(`Missing recommended docs: ${r.missingRecommended.join(', ')}`);
+        flags.push(
+          `Missing recommended docs: ${r.missingRecommended.join(', ')}`,
+        );
       if (r.manualChecks?.length > 0) {
         flags.push(`${r.manualChecks.length} manual check(s) needed`);
         for (const c of r.manualChecks) flags.push(`  → ${c}`);
       }
       sections.push({
         name: 'Source Access Mode',
-        status: !r.mode ? 'fail' : r.missingRequired?.length > 0 ? 'fail' : flags.length > 0 ? 'warn' : 'pass',
+        status: !r.mode
+          ? 'fail'
+          : r.missingRequired?.length > 0
+            ? 'fail'
+            : flags.length > 0
+              ? 'warn'
+              : 'pass',
         flags,
       });
     } else {
-      sections.push({ name: 'Source Access Mode', status: 'skip', flags: [`Check failed: ${sourceAccess.reason?.message || sourceAccess.reason || 'unknown error'}`] });
+      sections.push({
+        name: 'Source Access Mode',
+        status: 'skip',
+        flags: [
+          `Check failed: ${sourceAccess.reason?.message || sourceAccess.reason || 'unknown error'}`,
+        ],
+      });
     }
 
     // 4. Historical Consistency
@@ -2011,23 +2209,37 @@ export class DeviceReviewsService {
       const criticals = r.anomalies.filter((a) => a.severity === 'critical');
       const warnings = r.anomalies.filter((a) => a.severity === 'warning');
       const flags: string[] = [];
-      flags.push(`${r.totalReadings} reading(s) over ${r.periodMonths} month(s)`);
+      flags.push(
+        `${r.totalReadings} reading(s) over ${r.periodMonths} month(s)`,
+      );
       if (criticals.length > 0) {
         flags.push(`${criticals.length} critical anomaly(s)`);
-        for (const a of criticals.slice(0, 3)) flags.push(`  → ${a.description || a.type || 'anomaly'}`);
+        for (const a of criticals.slice(0, 3))
+          flags.push(`  → ${a.description || a.type || 'anomaly'}`);
       }
       if (warnings.length > 0) {
         flags.push(`${warnings.length} warning(s)`);
-        for (const a of warnings.slice(0, 3)) flags.push(`  → ${a.description || a.type || 'anomaly'}`);
+        for (const a of warnings.slice(0, 3))
+          flags.push(`  → ${a.description || a.type || 'anomaly'}`);
       }
       sections.push({
         name: 'Historical Consistency',
-        status: criticals.length > 0 ? 'fail' : warnings.length > 0 ? 'warn' : 'pass',
+        status:
+          criticals.length > 0 ? 'fail' : warnings.length > 0 ? 'warn' : 'pass',
         flags,
-        detail: { totalReadings: r.totalReadings, periodMonths: r.periodMonths },
+        detail: {
+          totalReadings: r.totalReadings,
+          periodMonths: r.periodMonths,
+        },
       });
     } else {
-      sections.push({ name: 'Historical Consistency', status: 'skip', flags: [`Check failed: ${consistency.reason?.message || consistency.reason || 'unknown error'}`] });
+      sections.push({
+        name: 'Historical Consistency',
+        status: 'skip',
+        flags: [
+          `Check failed: ${consistency.reason?.message || consistency.reason || 'unknown error'}`,
+        ],
+      });
     }
 
     // 5. Production Ceiling
@@ -2037,32 +2249,58 @@ export class DeviceReviewsService {
       if (r.configuredYield === null) {
         flags.push(`Capacity: ${r.capacityKw} kW, no yield value configured`);
       } else {
-        flags.push(`Capacity: ${r.capacityKw} kW, configured yield: ${r.configuredYield} kWh/kWp`);
+        flags.push(
+          `Capacity: ${r.capacityKw} kW, configured yield: ${r.configuredYield} kWh/kWp`,
+        );
       }
       if (r.irradiance) {
-        flags.push(`Irradiance band: ${r.irradiance.yieldLow}–${r.irradiance.yieldHigh} kWh/kWp/yr (lat ${r.irradiance.absLatitude.toFixed(1)}°), ceiling: ${r.irradiance.monthlyCeilingKwh.toFixed(0)} kWh/month`);
+        flags.push(
+          `Irradiance band: ${r.irradiance.yieldLow}–${r.irradiance.yieldHigh} kWh/kWp/yr (lat ${r.irradiance.absLatitude.toFixed(1)}°), ceiling: ${r.irradiance.monthlyCeilingKwh.toFixed(0)} kWh/month`,
+        );
       }
-      if (r.configuredYield === null) flags.push('No yield value configured — cannot compare against irradiance estimate');
-      else if (r.yieldMismatch) flags.push('Configured yield exceeds irradiance estimate');
-      const violations = r.recentReadings?.filter((rd: any) => rd.exceedsCeiling) || [];
-      if (violations.length > 0) flags.push(`${violations.length} reading(s) exceed ceiling`);
+      if (r.configuredYield === null)
+        flags.push(
+          'No yield value configured — cannot compare against irradiance estimate',
+        );
+      else if (r.yieldMismatch)
+        flags.push('Configured yield exceeds irradiance estimate');
+      const violations =
+        r.recentReadings?.filter((rd: any) => rd.exceedsCeiling) || [];
+      if (violations.length > 0)
+        flags.push(`${violations.length} reading(s) exceed ceiling`);
       const noYield = r.configuredYield === null;
       sections.push({
         name: 'Production Ceiling',
-        status: violations.length > 0 || r.yieldMismatch ? 'fail' : noYield ? 'warn' : 'pass',
+        status:
+          violations.length > 0 || r.yieldMismatch
+            ? 'fail'
+            : noYield
+              ? 'warn'
+              : 'pass',
         flags,
       });
     } else {
-      sections.push({ name: 'Production Ceiling', status: 'skip', flags: [`Check failed: ${ceiling.reason?.message || ceiling.reason || 'unknown error'}`] });
+      sections.push({
+        name: 'Production Ceiling',
+        status: 'skip',
+        flags: [
+          `Check failed: ${ceiling.reason?.message || ceiling.reason || 'unknown error'}`,
+        ],
+      });
     }
 
     // 6. Cross-Source
     if (crossSource.status === 'fulfilled') {
       const r = crossSource.value;
-      const criticals = r.flags?.filter((f: any) => f.severity === 'critical') || [];
-      const warnings = r.flags?.filter((f: any) => f.severity === 'warning') || [];
+      const criticals =
+        r.flags?.filter((f: any) => f.severity === 'critical') || [];
+      const warnings =
+        r.flags?.filter((f: any) => f.severity === 'warning') || [];
       const flags: string[] = [];
-      if (r.performanceFactor != null) flags.push(`Performance factor: ${(r.performanceFactor * 100).toFixed(1)}%`);
+      if (r.performanceFactor != null)
+        flags.push(
+          `Performance factor: ${(r.performanceFactor * 100).toFixed(1)}%`,
+        );
       if (r.rSquared != null) flags.push(`R²: ${r.rSquared.toFixed(3)}`);
       if (criticals.length > 0) {
         flags.push(`${criticals.length} critical flag(s)`);
@@ -2074,12 +2312,22 @@ export class DeviceReviewsService {
       }
       sections.push({
         name: 'Cross-Source Verification',
-        status: criticals.length > 0 ? 'fail' : warnings.length > 0 ? 'warn' : 'pass',
+        status:
+          criticals.length > 0 ? 'fail' : warnings.length > 0 ? 'warn' : 'pass',
         flags,
-        detail: { performanceFactor: r.performanceFactor, rSquared: r.rSquared },
+        detail: {
+          performanceFactor: r.performanceFactor,
+          rSquared: r.rSquared,
+        },
       });
     } else {
-      sections.push({ name: 'Cross-Source Verification', status: 'skip', flags: [`Check failed: ${crossSource.reason?.message || crossSource.reason || 'unknown error'}`] });
+      sections.push({
+        name: 'Cross-Source Verification',
+        status: 'skip',
+        flags: [
+          `Check failed: ${crossSource.reason?.message || crossSource.reason || 'unknown error'}`,
+        ],
+      });
     }
 
     // 7. Photo GPS
@@ -2089,26 +2337,47 @@ export class DeviceReviewsService {
       if (r.summary.total === 0) {
         flags.push('No project photos uploaded (minimum 3 required)');
       } else if (r.summary.total < 3) {
-        flags.push(`Only ${r.summary.total} photo(s) uploaded (minimum 3 required)`);
+        flags.push(
+          `Only ${r.summary.total} photo(s) uploaded (minimum 3 required)`,
+        );
       }
       if (r.summary.total > 0) {
-        flags.push(`${r.summary.total} photo(s), ${r.summary.withGps} with GPS data`);
+        flags.push(
+          `${r.summary.total} photo(s), ${r.summary.withGps} with GPS data`,
+        );
         const noGps = r.summary.total - r.summary.withGps;
         if (noGps > 0) flags.push(`${noGps} photo(s) without GPS metadata`);
         if (r.summary.flagged > 0) {
-          flags.push(`${r.summary.flagged} photo(s) exceed ${r.thresholdMeters}m from declared location`);
-          for (const p of (r.photos || []).filter((ph: any) => ph.flagged).slice(0, 3)) {
-            flags.push(`  → ${p.fileName || 'photo'}: ${p.distanceMeters?.toFixed(0) || '?'}m away`);
+          flags.push(
+            `${r.summary.flagged} photo(s) exceed ${r.thresholdMeters}m from declared location`,
+          );
+          for (const p of (r.photos || [])
+            .filter((ph: any) => ph.flagged)
+            .slice(0, 3)) {
+            flags.push(
+              `  → ${p.fileName || 'photo'}: ${p.distanceMeters?.toFixed(0) || '?'}m away`,
+            );
           }
         }
       }
       sections.push({
         name: 'Photo GPS',
-        status: r.summary.flagged > 0 || r.summary.total < 3 ? 'fail' : (r.summary.total - r.summary.withGps) > 0 ? 'warn' : 'pass',
+        status:
+          r.summary.flagged > 0 || r.summary.total < 3
+            ? 'fail'
+            : r.summary.total - r.summary.withGps > 0
+              ? 'warn'
+              : 'pass',
         flags,
       });
     } else {
-      sections.push({ name: 'Photo GPS', status: 'skip', flags: [`Check failed: ${photoGps.reason?.message || photoGps.reason || 'unknown error'}`] });
+      sections.push({
+        name: 'Photo GPS',
+        status: 'skip',
+        flags: [
+          `Check failed: ${photoGps.reason?.message || photoGps.reason || 'unknown error'}`,
+        ],
+      });
     }
 
     // 8. Compensating Controls (only relevant for Mode 4)
@@ -2127,7 +2396,13 @@ export class DeviceReviewsService {
     // If controls check failed but was attempted, still skip
     if (controls.status === 'rejected') {
       // Only add if we can't tell whether it's Mode 4 — err on side of inclusion
-      sections.push({ name: 'Compensating Controls', status: 'skip', flags: [`Check failed: ${controls.reason?.message || controls.reason || 'unknown error'}`] });
+      sections.push({
+        name: 'Compensating Controls',
+        status: 'skip',
+        flags: [
+          `Check failed: ${controls.reason?.message || controls.reason || 'unknown error'}`,
+        ],
+      });
     }
 
     // 9. SLD Capacity Compare
@@ -2135,15 +2410,31 @@ export class DeviceReviewsService {
       const r = sldCompare.value;
       const flags: string[] = [];
       if (!r.hasSld) flags.push('No SLD document uploaded');
-      else if (r.sldCapacityKw == null) flags.push('SLD capacity not yet entered by reviewer');
-      else if (r.match === false) flags.push(`SLD says ${r.sldCapacityKw} kW, registered ${r.registeredCapacityKw} kW (${r.differencePercent > 0 ? '+' : ''}${r.differencePercent}%)`);
+      else if (r.sldCapacityKw == null)
+        flags.push('SLD capacity not yet entered by reviewer');
+      else if (r.match === false)
+        flags.push(
+          `SLD says ${r.sldCapacityKw} kW, registered ${r.registeredCapacityKw} kW (${r.differencePercent > 0 ? '+' : ''}${r.differencePercent}%)`,
+        );
       sections.push({
         name: 'SLD Capacity Compare',
-        status: !r.hasSld ? 'fail' : r.match === false ? 'fail' : r.match === true ? 'pass' : 'warn',
+        status: !r.hasSld
+          ? 'fail'
+          : r.match === false
+            ? 'fail'
+            : r.match === true
+              ? 'pass'
+              : 'warn',
         flags,
       });
     } else {
-      sections.push({ name: 'SLD Capacity Compare', status: 'skip', flags: [`Check failed: ${sldCompare.reason?.message || sldCompare.reason || 'unknown error'}`] });
+      sections.push({
+        name: 'SLD Capacity Compare',
+        status: 'skip',
+        flags: [
+          `Check failed: ${sldCompare.reason?.message || sldCompare.reason || 'unknown error'}`,
+        ],
+      });
     }
 
     // 10. Country Match (lat/lng vs declared country, with disputed-territory neutrality)
@@ -2159,8 +2450,12 @@ export class DeviceReviewsService {
       switch (r.status) {
         case 'match':
           status = 'pass';
-          flags.push(`${nameOf(r.declaredCountry)} confirmed by reverse-geocode.`);
-          flags.push('Coordinates are not in any known disputed-border region.');
+          flags.push(
+            `${nameOf(r.declaredCountry)} confirmed by reverse-geocode.`,
+          );
+          flags.push(
+            'Coordinates are not in any known disputed-border region.',
+          );
           break;
         case 'disputed':
           status = 'warn';
@@ -2193,20 +2488,31 @@ export class DeviceReviewsService {
       sections.push({
         name: 'Country Match',
         status: 'skip',
-        flags: [`Check failed: ${countryMatch.reason?.message || countryMatch.reason || 'unknown error'}`],
+        flags: [
+          `Check failed: ${countryMatch.reason?.message || countryMatch.reason || 'unknown error'}`,
+        ],
       });
     }
 
     // Overall status
-    const hasAnyFail = sections.some((s) => s.status === 'fail' || s.status === 'skip');
+    const hasAnyFail = sections.some(
+      (s) => s.status === 'fail' || s.status === 'skip',
+    );
     const hasAnyWarn = sections.some((s) => s.status === 'warn');
     const overallStatus = hasAnyFail ? 'fail' : hasAnyWarn ? 'warn' : 'pass';
 
     const now = new Date().toISOString();
 
-    await this.logAudit(deviceId, 'auto_screen_report',
-      `Auto-screen: ${overallStatus} — ${sections.filter(s => s.status === 'fail').length} fail, ${sections.filter(s => s.status === 'warn').length} warn, ${sections.filter(s => s.status === 'pass').length} pass`,
-      'reviewer', { overallStatus, sections: sections.map(s => ({ name: s.name, status: s.status })) });
+    await this.logAudit(
+      deviceId,
+      'auto_screen_report',
+      `Auto-screen: ${overallStatus} — ${sections.filter((s) => s.status === 'fail').length} fail, ${sections.filter((s) => s.status === 'warn').length} warn, ${sections.filter((s) => s.status === 'pass').length} pass`,
+      'reviewer',
+      {
+        overallStatus,
+        sections: sections.map((s) => ({ name: s.name, status: s.status })),
+      },
+    );
 
     // Persist last screen result on device
     await this.connection.query(
@@ -2241,9 +2547,13 @@ export class DeviceReviewsService {
       `UPDATE device SET sld_capacity_kw = $1 WHERE id = $2`,
       [sldCapacityKw, deviceId],
     );
-    await this.logAudit(deviceId, 'sld_capacity_set',
+    await this.logAudit(
+      deviceId,
+      'sld_capacity_set',
       `SLD capacity set to ${sldCapacityKw} kW`,
-      'reviewer', { sldCapacityKw });
+      'reviewer',
+      { sldCapacityKw },
+    );
     return { sldCapacityKw };
   }
 
@@ -2267,8 +2577,12 @@ export class DeviceReviewsService {
     if (rows.length === 0) {
       throw new NotFoundException(`Device ${deviceId} not found`);
     }
-    const registered = rows[0].capacity != null ? parseFloat(rows[0].capacity) : null;
-    const sld = rows[0].sld_capacity_kw != null ? parseFloat(rows[0].sld_capacity_kw) : null;
+    const registered =
+      rows[0].capacity != null ? parseFloat(rows[0].capacity) : null;
+    const sld =
+      rows[0].sld_capacity_kw != null
+        ? parseFloat(rows[0].sld_capacity_kw)
+        : null;
 
     // Check if SLD document exists
     const docs = await this.connection.query(
@@ -2290,9 +2604,12 @@ export class DeviceReviewsService {
       };
     }
 
-    const diff = registered > 0
-      ? ((sld - registered) / registered) * 100
-      : (sld === 0 ? 0 : 100);
+    const diff =
+      registered > 0
+        ? ((sld - registered) / registered) * 100
+        : sld === 0
+          ? 0
+          : 100;
     const match = Math.abs(diff) <= TOLERANCE;
 
     return {
@@ -2310,7 +2627,8 @@ export class DeviceReviewsService {
     status: string,
     ipAddress?: string,
   ): Promise<Array<{ deviceId: number; status: string; error?: string }>> {
-    const results: Array<{ deviceId: number; status: string; error?: string }> = [];
+    const results: Array<{ deviceId: number; status: string; error?: string }> =
+      [];
     for (const id of deviceIds) {
       try {
         const res = await this.updateReviewStatus(id, status, ipAddress);
@@ -2320,7 +2638,9 @@ export class DeviceReviewsService {
       }
     }
     // Log bulk action to audit trail for each affected device
-    const succeeded = results.filter((r) => r.status !== 'error').map((r) => r.deviceId);
+    const succeeded = results
+      .filter((r) => r.status !== 'error')
+      .map((r) => r.deviceId);
     for (const id of succeeded) {
       await this.logAudit(
         id,
@@ -2336,7 +2656,9 @@ export class DeviceReviewsService {
 
   async bulkAutoScreen(
     deviceIds?: number[],
-  ): Promise<Array<{ deviceId: number; overallStatus: string; error?: string }>> {
+  ): Promise<
+    Array<{ deviceId: number; overallStatus: string; error?: string }>
+  > {
     // If no IDs provided, screen all unscreened pending devices
     let ids = deviceIds;
     if (!ids || ids.length === 0) {
@@ -2356,13 +2678,21 @@ export class DeviceReviewsService {
       ids = rows.map((r) => r.id);
     }
 
-    const results: Array<{ deviceId: number; overallStatus: string; error?: string }> = [];
+    const results: Array<{
+      deviceId: number;
+      overallStatus: string;
+      error?: string;
+    }> = [];
     for (const id of ids) {
       try {
         const res = await this.autoScreenReport(id);
         results.push({ deviceId: id, overallStatus: res.overallStatus });
       } catch (err: any) {
-        results.push({ deviceId: id, overallStatus: 'error', error: err.message });
+        results.push({
+          deviceId: id,
+          overallStatus: 'error',
+          error: err.message,
+        });
       }
     }
     return results;
@@ -2413,7 +2743,9 @@ export class DeviceReviewsService {
 
     const commDate = dev.commissioningDate
       ? new Date(dev.commissioningDate).toLocaleDateString('en-GB', {
-          day: '2-digit', month: 'long', year: 'numeric',
+          day: '2-digit',
+          month: 'long',
+          year: 'numeric',
         })
       : 'Not specified';
 
@@ -2423,24 +2755,38 @@ export class DeviceReviewsService {
       { label: 'Organization', value: dev.orgName || '—' },
       { label: 'Serial Number', value: dev.serialNumber || '—' },
       { label: 'Country', value: dev.countryCode || '—' },
-      { label: 'Location', value: dev.latitude && dev.longitude
-        ? `${parseFloat(dev.latitude).toFixed(6)}, ${parseFloat(dev.longitude).toFixed(6)}`
-        : '—' },
+      {
+        label: 'Location',
+        value:
+          dev.latitude && dev.longitude
+            ? `${parseFloat(dev.latitude).toFixed(6)}, ${parseFloat(dev.longitude).toFixed(6)}`
+            : '—',
+      },
       { label: 'Address', value: dev.address || '—' },
-      { label: 'Capacity (kW)', value: dev.capacity != null ? String(dev.capacity) : '—' },
+      {
+        label: 'Capacity (kW)',
+        value: dev.capacity != null ? String(dev.capacity) : '—',
+      },
       { label: 'Fuel Type', value: dev.fuelCode || '—' },
       { label: 'Device Type', value: dev.deviceTypeCode || '—' },
-      { label: 'Grid Interconnection', value: dev.gridInterconnection ? 'Yes' : 'No' },
-      { label: 'Operating Configuration', value: dev.operatingConfiguration || '—' },
+      {
+        label: 'Grid Interconnection',
+        value: dev.gridInterconnection ? 'Yes' : 'No',
+      },
+      {
+        label: 'Operating Configuration',
+        value: dev.operatingConfiguration || '—',
+      },
       { label: 'Source Access Mode', value: dev.sourceAccessMode || '—' },
       { label: 'Commissioning Date', value: commDate },
     ];
 
-    const docs: Array<{ type: string; cnt: string }> = await this.connection.query(
-      `SELECT type, COUNT(*)::text AS cnt FROM documents WHERE target_type = 'device' AND target_id = $1 GROUP BY type`,
-      [deviceId],
-    );
-    const typeCounts = new Map(docs.map(d => [d.type, parseInt(d.cnt, 10)]));
+    const docs: Array<{ type: string; cnt: string }> =
+      await this.connection.query(
+        `SELECT type, COUNT(*)::text AS cnt FROM documents WHERE target_type = 'device' AND target_id = $1 GROUP BY type`,
+        [deviceId],
+      );
+    const typeCounts = new Map(docs.map((d) => [d.type, parseInt(d.cnt, 10)]));
     const allDocs = [
       { type: 'SINGLE_LINE_DIAGRAM', required: true, minCount: 1 },
       { type: 'SF_02C', required: false, minCount: 1 },
@@ -2449,7 +2795,7 @@ export class DeviceReviewsService {
       { type: 'METERING_EVIDENCE', required: false, minCount: 1 },
       { type: 'PROJECT_PHOTOS', required: true, minCount: 3 },
     ];
-    const documents = allDocs.map(d => ({
+    const documents = allDocs.map((d) => ({
       type: d.type,
       present: (typeCounts.get(d.type) ?? 0) >= d.minCount,
       count: typeCounts.get(d.type) ?? 0,
@@ -2460,7 +2806,9 @@ export class DeviceReviewsService {
     return { fields, documents };
   }
 
-  async generateSf02(deviceId: number): Promise<{ url: string; docId: number }> {
+  async generateSf02(
+    deviceId: number,
+  ): Promise<{ url: string; docId: number }> {
     const dev = await this.fetchSf02DeviceData(deviceId);
 
     // Build the PDF
@@ -2524,7 +2872,10 @@ export class DeviceReviewsService {
       doc
         .fontSize(10)
         .fillColor('#64748b')
-        .text('Green South B.V. — D-REC Platform', 60, 40, { align: 'right', width: pageWidth });
+        .text('Green South B.V. — D-REC Platform', 60, 40, {
+          align: 'right',
+          width: pageWidth,
+        });
 
       doc.moveDown(1.5);
 
@@ -2532,7 +2883,10 @@ export class DeviceReviewsService {
       doc
         .fontSize(22)
         .fillColor('#0f172a')
-        .text('SF-02 — Production Facility Registration', { align: 'center', width: pageWidth });
+        .text('SF-02 — Production Facility Registration', {
+          align: 'center',
+          width: pageWidth,
+        });
 
       doc.moveDown(0.3);
       doc
@@ -2565,7 +2919,7 @@ export class DeviceReviewsService {
         .fillColor('#334155')
         .text(
           `This document registers the renewable energy production facility described below ` +
-          `on the D-REC Platform operated by Green South B.V.`,
+            `on the D-REC Platform operated by Green South B.V.`,
           { width: pageWidth, lineGap: 4 },
         );
 
@@ -2578,9 +2932,12 @@ export class DeviceReviewsService {
         ['Organization', dev.orgName || '—'],
         ['Serial Number', dev.serialNumber || '—'],
         ['Country', dev.countryCode || '—'],
-        ['Location', dev.latitude && dev.longitude
-          ? `${parseFloat(dev.latitude).toFixed(6)}, ${parseFloat(dev.longitude).toFixed(6)}`
-          : '—'],
+        [
+          'Location',
+          dev.latitude && dev.longitude
+            ? `${parseFloat(dev.latitude).toFixed(6)}, ${parseFloat(dev.longitude).toFixed(6)}`
+            : '—',
+        ],
         ['Address', dev.address || '—'],
         ['Capacity (kW)', dev.capacity != null ? String(dev.capacity) : '—'],
         ['Fuel Type', dev.fuelCode || '—'],
@@ -2631,7 +2988,7 @@ export class DeviceReviewsService {
         .moveDown(0.3)
         .text(
           'This registration form was automatically generated by the D-REC Platform. ' +
-          'It confirms that the above production facility is registered in the system.',
+            'It confirms that the above production facility is registered in the system.',
           { width: pageWidth, lineGap: 3 },
         );
 
@@ -2651,8 +3008,10 @@ export class DeviceReviewsService {
 
 /** Haversine distance in meters between two lat/lng points. */
 function haversineMeters(
-  lat1: number, lng1: number,
-  lat2: number, lng2: number,
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
 ): number {
   const R = 6_371_000; // Earth radius in meters
   const toRad = (d: number) => (d * Math.PI) / 180;

--- a/apps/drec-api/src/pods/solar-yield/README.md
+++ b/apps/drec-api/src/pods/solar-yield/README.md
@@ -1,0 +1,61 @@
+# solar-yield
+
+TypeScript port of [`KNaik1695/solar-monthly-predictionModel`](https://github.com/KNaik1695/solar-monthly-predictionModel) — a nearest-neighbour lookup over a precomputed Global Solar Atlas grid that estimates monthly + annual PV yield for a site.
+
+Tracks the fix branch under review as [PR #1](https://github.com/KNaik1695/solar-monthly-predictionModel/pull/1): correct days-vector indexing in Case B, a pre-COD guard, and the correction factor applied to Model 2 Case B.
+
+## What it is / isn't
+
+- **Is:** a typical-year climatology — same estimate regardless of the weather that actually occurred in the queried year.
+- **Isn't:** a weather-corrected estimator. Inter-annual variability can swing real output ±10–15% at monthly scale, ±5–8% annual.
+
+Use it for **past-generation confirmations against a tolerance band**, not as ground truth.
+
+## Usage
+
+```ts
+import { SolarYieldModule } from './pods/solar-yield/solar-yield.module';
+// register SolarYieldModule in your AppModule
+
+// then inject:
+constructor(private readonly solar: SolarYieldService) {}
+
+const result = this.solar.getSolarEnergy(
+  19.745365,        // lat
+  105.901337,       // lon
+  29.25,            // capacity in kW
+  '2024-06-01',     // Commercial Operation Date
+  2025,             // target year
+);
+// → { Model_1_Outputs: { Yield_kWh, Monthly_kWh, ... }, Model_2_Outputs: { ... } }
+```
+
+## Data file
+
+The service needs `pv_potential_3d.npz` (~73 MB, ~311 MB uncompressed) at runtime. It is **not** committed to this repo.
+
+Point the env var `SOLAR_GRID_NPZ_PATH` at an absolute path:
+
+```bash
+SOLAR_GRID_NPZ_PATH=/opt/drec/solar/pv_potential_3d.npz pnpm start:dev
+```
+
+Source of truth: [`KNaik1695/solar-monthly-predictionModel/pv_potential_3d.npz`](https://github.com/KNaik1695/solar-monthly-predictionModel/blob/main/pv_potential_3d.npz). Pin to the same commit you ported against (currently the PR#1 branch). At deploy time, provide the file via a volume mount or init-container download; at local dev, symlink or copy in.
+
+On startup, the service parses the `.npz` (no scipy/numpy needed — stdlib `zlib.inflateRawSync` + a small `.npy` header parser in `npz-reader.ts`) and keeps the grid in memory as typed arrays. Grid load time: ~200–400 ms on a laptop; ~330 MB resident memory.
+
+## Known caveats
+
+- **Silent out-of-bounds → 0.** Matches scipy's `fill_value=0` default in the Python reference; a typo in lat/lon produces a 0-kWh estimate rather than an error. If you integrate this into a code path where "0" means "this device generated nothing" rather than "invalid query," wrap it with a bounds check.
+- **Nearest-neighbour at grid resolution (1/12°, ~9 km).** Two sites within ~5 km of each other may resolve to the same grid cell and return identical estimates.
+- **Model 2 is weak.** It's a `capacity × static-annual-yield-per-kW` baseline that exists for parity with the Python output shape. It makes no use of the grid at all. Treat it as a sanity-check baseline, not an independent estimate.
+
+## Updating to match upstream changes
+
+If Kartik ships a new version of `prediction_model.py`, update in lockstep:
+
+- `solar-yield.service.ts` for algorithm changes
+- `config.ts` for constant changes (`staticAvg`, `PF_avg`, `DF`, version strings)
+- `solar-yield.service.spec.ts` for any behavior changes
+
+The tests use a synthetic identity grid (every month returns a trivial value), so they cover the algorithm without needing the real `.npz` in CI.

--- a/apps/drec-api/src/pods/solar-yield/README.md
+++ b/apps/drec-api/src/pods/solar-yield/README.md
@@ -46,7 +46,7 @@ On startup, the service parses the `.npz` (no scipy/numpy needed — stdlib `zli
 
 ## Known caveats
 
-- **Silent out-of-bounds → 0.** Matches scipy's `fill_value=0` default in the Python reference; a typo in lat/lon produces a 0-kWh estimate rather than an error. If you integrate this into a code path where "0" means "this device generated nothing" rather than "invalid query," wrap it with a bounds check.
+- **Out-of-bounds coordinates throw `RangeError`.** The Python reference silently returns 0 (scipy's `fill_value=0` default); we diverge here so callers can distinguish a typo'd coordinate from a real zero (polar winter, etc.).
 - **Nearest-neighbour at grid resolution (1/12°, ~9 km).** Two sites within ~5 km of each other may resolve to the same grid cell and return identical estimates.
 - **Model 2 is weak.** It's a `capacity × static-annual-yield-per-kW` baseline that exists for parity with the Python output shape. It makes no use of the grid at all. Treat it as a sanity-check baseline, not an independent estimate.
 

--- a/apps/drec-api/src/pods/solar-yield/config.ts
+++ b/apps/drec-api/src/pods/solar-yield/config.ts
@@ -1,0 +1,20 @@
+/**
+ * Static model parameters, mirroring Kartik's `config.py`.
+ *
+ * The Python upstream revision this matches is the one under review in
+ * KNaik1695/solar-monthly-predictionModel PR #1 (fixed days-vector indexing,
+ * pre-COD guard, and Model 2 Case B correction). If upstream shifts any of
+ * these numbers, update here too.
+ */
+export const SOLAR_MODEL_CONFIG = {
+  /** Linear-regression baseline annual yield per kW (kWh/kWp/year). */
+  staticAvg: 1520,
+  /** Year-over-year degradation factor. */
+  DF: 0.005,
+  /** Default assumed performance factor. */
+  PF_avg: 0.778,
+  /** Semver-tagged model versions exposed in output so downstream consumers
+   * can detect when the estimate changed. */
+  solarGsaVersion: 'v1.2.0',
+  linearRegressionVersion: 'v1.1.0',
+};

--- a/apps/drec-api/src/pods/solar-yield/npz-reader.ts
+++ b/apps/drec-api/src/pods/solar-yield/npz-reader.ts
@@ -11,12 +11,12 @@ import { readFileSync } from 'fs';
  * coercing, since this is deployment-time config, not user input.
  */
 export interface SolarGrid {
-  pv: Float32Array;         // length Nlon * Nlat * 12, C-order (lon, lat, month)
-  lons: Float64Array;       // Nlon
-  lats: Float64Array;       // Nlat
+  pv: Float32Array; // length Nlon * Nlat * 12, C-order (lon, lat, month)
+  lons: Float64Array; // Nlon
+  lats: Float64Array; // Nlat
   nLon: number;
   nLat: number;
-  nMonths: number;          // always 12
+  nMonths: number; // always 12
 }
 
 export function readSolarGrid(npzPath: string): SolarGrid {
@@ -41,15 +41,21 @@ export function readSolarGrid(npzPath: string): SolarGrid {
   assertNoFortran(latsMeta, 'lats');
 
   if (pvMeta.shape.length !== 3 || pvMeta.shape[2] !== 12) {
-    throw new Error(`pv_data shape expected (Nlon, Nlat, 12); got ${JSON.stringify(pvMeta.shape)}`);
+    throw new Error(
+      `pv_data shape expected (Nlon, Nlat, 12); got ${JSON.stringify(pvMeta.shape)}`,
+    );
   }
   const [nLon, nLat, nMonths] = pvMeta.shape;
 
   if (lonsMeta.shape.length !== 1 || lonsMeta.shape[0] !== nLon) {
-    throw new Error(`lons shape ${JSON.stringify(lonsMeta.shape)} mismatches pv_data Nlon=${nLon}`);
+    throw new Error(
+      `lons shape ${JSON.stringify(lonsMeta.shape)} mismatches pv_data Nlon=${nLon}`,
+    );
   }
   if (latsMeta.shape.length !== 1 || latsMeta.shape[0] !== nLat) {
-    throw new Error(`lats shape ${JSON.stringify(latsMeta.shape)} mismatches pv_data Nlat=${nLat}`);
+    throw new Error(
+      `lats shape ${JSON.stringify(latsMeta.shape)} mismatches pv_data Nlat=${nLat}`,
+    );
   }
 
   const pv = toFloat32(pvBytes, pvMeta.descr, nLon * nLat * nMonths);
@@ -61,13 +67,21 @@ export function readSolarGrid(npzPath: string): SolarGrid {
   // in `lats` AND in `pv` (which indexes as [lon, lat, month] C-order).
   // In-place is ~40 M float swaps for the current grid — fast and avoids a
   // 300-MB peak allocation during load.
-  if (lons.length > 1 && lons[0] > lons[lons.length - 1]) reverseLons(pv, lons, nLon, nLat, nMonths);
-  if (lats.length > 1 && lats[0] > lats[lats.length - 1]) reverseLats(pv, lats, nLon, nLat, nMonths);
+  if (lons.length > 1 && lons[0] > lons[lons.length - 1])
+    reverseLons(pv, lons, nLon, nLat, nMonths);
+  if (lats.length > 1 && lats[0] > lats[lats.length - 1])
+    reverseLats(pv, lats, nLon, nLat, nMonths);
 
   return { pv, lons, lats, nLon, nLat, nMonths };
 }
 
-function reverseLats(pv: Float32Array, lats: Float64Array, nLon: number, nLat: number, nMonths: number): void {
+function reverseLats(
+  pv: Float32Array,
+  lats: Float64Array,
+  nLon: number,
+  nLat: number,
+  nMonths: number,
+): void {
   // Reverse lats in place.
   for (let i = 0, j = nLat - 1; i < j; i++, j--) {
     const t = lats[i];
@@ -90,7 +104,13 @@ function reverseLats(pv: Float32Array, lats: Float64Array, nLon: number, nLat: n
   }
 }
 
-function reverseLons(pv: Float32Array, lons: Float64Array, nLon: number, nLat: number, nMonths: number): void {
+function reverseLons(
+  pv: Float32Array,
+  lons: Float64Array,
+  nLon: number,
+  nLat: number,
+  nMonths: number,
+): void {
   for (let i = 0, j = nLon - 1; i < j; i++, j--) {
     const t = lons[i];
     lons[i] = lons[j];
@@ -112,7 +132,7 @@ function reverseLons(pv: Float32Array, lons: Float64Array, nLon: number, nLat: n
 // ── npy + zip internals ──────────────────────────────────────────────────────
 
 interface NpyMeta {
-  descr: string;                   // e.g. '<f4', '<f8'
+  descr: string; // e.g. '<f4', '<f8'
   fortran_order: boolean;
   shape: number[];
 }
@@ -134,7 +154,10 @@ function parseNpy(raw: Buffer): { meta: NpyMeta; data: Buffer } {
     throw new Error(`unsupported .npy version ${major}`);
   }
 
-  const headerStr = raw.slice(headerStart, headerStart + headerLen).toString('latin1').trim();
+  const headerStr = raw
+    .slice(headerStart, headerStart + headerLen)
+    .toString('latin1')
+    .trim();
   const meta = parsePythonDictLiteral(headerStr);
   return {
     meta: {
@@ -152,7 +175,11 @@ function parseNpy(raw: Buffer): { meta: NpyMeta; data: Buffer } {
  * or a tuple of ints. We hand-roll a small tokenizer rather than eval() the
  * string.
  */
-function parsePythonDictLiteral(s: string): { descr: string; fortran_order: boolean; shape: number[] } {
+function parsePythonDictLiteral(s: string): {
+  descr: string;
+  fortran_order: boolean;
+  shape: number[];
+} {
   const descr = s.match(/'descr'\s*:\s*'([^']+)'/)?.[1];
   const fortranStr = s.match(/'fortran_order'\s*:\s*(True|False)/)?.[1];
   const shapeStr = s.match(/'shape'\s*:\s*\(([^)]*)\)/)?.[1];
@@ -179,11 +206,13 @@ function assertNoFortran(meta: NpyMeta, name: string): void {
 
 function toFloat32(buf: Buffer, descr: string, n: number): Float32Array {
   if (descr === '<f4') {
-    if (buf.length < n * 4) throw new Error(`float32 buffer short: ${buf.length} < ${n * 4}`);
+    if (buf.length < n * 4)
+      throw new Error(`float32 buffer short: ${buf.length} < ${n * 4}`);
     return new Float32Array(buf.buffer, buf.byteOffset, n);
   }
   if (descr === '<f8') {
-    if (buf.length < n * 8) throw new Error(`float64 buffer short: ${buf.length} < ${n * 8}`);
+    if (buf.length < n * 8)
+      throw new Error(`float64 buffer short: ${buf.length} < ${n * 8}`);
     const src = new Float64Array(buf.buffer, buf.byteOffset, n);
     const out = new Float32Array(n);
     for (let i = 0; i < n; i++) out[i] = src[i];
@@ -194,11 +223,13 @@ function toFloat32(buf: Buffer, descr: string, n: number): Float32Array {
 
 function toFloat64(buf: Buffer, descr: string, n: number): Float64Array {
   if (descr === '<f8') {
-    if (buf.length < n * 8) throw new Error(`float64 buffer short: ${buf.length} < ${n * 8}`);
+    if (buf.length < n * 8)
+      throw new Error(`float64 buffer short: ${buf.length} < ${n * 8}`);
     return new Float64Array(buf.buffer, buf.byteOffset, n);
   }
   if (descr === '<f4') {
-    if (buf.length < n * 4) throw new Error(`float32 buffer short: ${buf.length} < ${n * 4}`);
+    if (buf.length < n * 4)
+      throw new Error(`float32 buffer short: ${buf.length} < ${n * 4}`);
     const src = new Float32Array(buf.buffer, buf.byteOffset, n);
     const out = new Float64Array(n);
     for (let i = 0; i < n; i++) out[i] = src[i];
@@ -213,7 +244,11 @@ function readZipEntries(zip: Buffer): Map<string, Buffer> {
   // Find End of Central Directory (EOCD): last 22 bytes plus optional comment.
   const EOCD_SIG = 0x06054b50;
   let eocdOffset = -1;
-  for (let i = zip.length - 22; i >= Math.max(0, zip.length - 0xffff - 22); i--) {
+  for (
+    let i = zip.length - 22;
+    i >= Math.max(0, zip.length - 0xffff - 22);
+    i--
+  ) {
     if (zip.readUInt32LE(i) === EOCD_SIG) {
       eocdOffset = i;
       break;
@@ -258,7 +293,9 @@ function readZipEntries(zip: Buffer): Map<string, Buffer> {
     } else if (compressionMethod === 8) {
       data = inflateRawSync(zip.slice(dataStart, dataEnd));
     } else {
-      throw new Error(`zip: unsupported compression method ${compressionMethod} for ${name}`);
+      throw new Error(
+        `zip: unsupported compression method ${compressionMethod} for ${name}`,
+      );
     }
     if (data.length !== uncompressedSize) {
       throw new Error(

--- a/apps/drec-api/src/pods/solar-yield/npz-reader.ts
+++ b/apps/drec-api/src/pods/solar-yield/npz-reader.ts
@@ -204,35 +204,45 @@ function assertNoFortran(meta: NpyMeta, name: string): void {
   }
 }
 
+// Node's `Buffer.slice` and `inflateRawSync` outputs do NOT guarantee that
+// `byteOffset` is a multiple of 4 or 8. `new Float32Array(buf.buffer,
+// buf.byteOffset, n)` throws `RangeError: start offset of Float32Array should
+// be a multiple of 4` on misaligned inputs. We read through a DataView so the
+// alignment requirement disappears.
+
 function toFloat32(buf: Buffer, descr: string, n: number): Float32Array {
+  const out = new Float32Array(n);
   if (descr === '<f4') {
     if (buf.length < n * 4)
       throw new Error(`float32 buffer short: ${buf.length} < ${n * 4}`);
-    return new Float32Array(buf.buffer, buf.byteOffset, n);
+    const view = new DataView(buf.buffer, buf.byteOffset, n * 4);
+    for (let i = 0; i < n; i++) out[i] = view.getFloat32(i * 4, true);
+    return out;
   }
   if (descr === '<f8') {
     if (buf.length < n * 8)
       throw new Error(`float64 buffer short: ${buf.length} < ${n * 8}`);
-    const src = new Float64Array(buf.buffer, buf.byteOffset, n);
-    const out = new Float32Array(n);
-    for (let i = 0; i < n; i++) out[i] = src[i];
+    const view = new DataView(buf.buffer, buf.byteOffset, n * 8);
+    for (let i = 0; i < n; i++) out[i] = view.getFloat64(i * 8, true); // downcast
     return out;
   }
   throw new Error(`unsupported dtype for float32 target: ${descr}`);
 }
 
 function toFloat64(buf: Buffer, descr: string, n: number): Float64Array {
+  const out = new Float64Array(n);
   if (descr === '<f8') {
     if (buf.length < n * 8)
       throw new Error(`float64 buffer short: ${buf.length} < ${n * 8}`);
-    return new Float64Array(buf.buffer, buf.byteOffset, n);
+    const view = new DataView(buf.buffer, buf.byteOffset, n * 8);
+    for (let i = 0; i < n; i++) out[i] = view.getFloat64(i * 8, true);
+    return out;
   }
   if (descr === '<f4') {
     if (buf.length < n * 4)
       throw new Error(`float32 buffer short: ${buf.length} < ${n * 4}`);
-    const src = new Float32Array(buf.buffer, buf.byteOffset, n);
-    const out = new Float64Array(n);
-    for (let i = 0; i < n; i++) out[i] = src[i];
+    const view = new DataView(buf.buffer, buf.byteOffset, n * 4);
+    for (let i = 0; i < n; i++) out[i] = view.getFloat32(i * 4, true);
     return out;
   }
   throw new Error(`unsupported dtype for float64 target: ${descr}`);

--- a/apps/drec-api/src/pods/solar-yield/npz-reader.ts
+++ b/apps/drec-api/src/pods/solar-yield/npz-reader.ts
@@ -1,0 +1,277 @@
+import { inflateRawSync } from 'zlib';
+import { readFileSync } from 'fs';
+
+/**
+ * Minimal stdlib-only reader for `.npz` archives containing the three arrays
+ * used by the solar potential grid: `pv_data` (Nlon×Nlat×12, float32),
+ * `lons` (Nlon, float64), `lats` (Nlat, float64).
+ *
+ * `.npz` is a ZIP archive of `.npy` files; we parse only what we need (DEFLATE +
+ * the numpy v1 header). Throws on any format deviation instead of silently
+ * coercing, since this is deployment-time config, not user input.
+ */
+export interface SolarGrid {
+  pv: Float32Array;         // length Nlon * Nlat * 12, C-order (lon, lat, month)
+  lons: Float64Array;       // Nlon
+  lats: Float64Array;       // Nlat
+  nLon: number;
+  nLat: number;
+  nMonths: number;          // always 12
+}
+
+export function readSolarGrid(npzPath: string): SolarGrid {
+  const buf = readFileSync(npzPath);
+  const entries = readZipEntries(buf);
+
+  const pvEntry = entries.get('pv_data.npy');
+  const lonsEntry = entries.get('lons.npy');
+  const latsEntry = entries.get('lats.npy');
+  if (!pvEntry || !lonsEntry || !latsEntry) {
+    throw new Error(
+      `solar grid npz missing one of pv_data/lons/lats; got: ${[...entries.keys()].join(', ')}`,
+    );
+  }
+
+  const { meta: pvMeta, data: pvBytes } = parseNpy(pvEntry);
+  const { meta: lonsMeta, data: lonsBytes } = parseNpy(lonsEntry);
+  const { meta: latsMeta, data: latsBytes } = parseNpy(latsEntry);
+
+  assertNoFortran(pvMeta, 'pv_data');
+  assertNoFortran(lonsMeta, 'lons');
+  assertNoFortran(latsMeta, 'lats');
+
+  if (pvMeta.shape.length !== 3 || pvMeta.shape[2] !== 12) {
+    throw new Error(`pv_data shape expected (Nlon, Nlat, 12); got ${JSON.stringify(pvMeta.shape)}`);
+  }
+  const [nLon, nLat, nMonths] = pvMeta.shape;
+
+  if (lonsMeta.shape.length !== 1 || lonsMeta.shape[0] !== nLon) {
+    throw new Error(`lons shape ${JSON.stringify(lonsMeta.shape)} mismatches pv_data Nlon=${nLon}`);
+  }
+  if (latsMeta.shape.length !== 1 || latsMeta.shape[0] !== nLat) {
+    throw new Error(`lats shape ${JSON.stringify(latsMeta.shape)} mismatches pv_data Nlat=${nLat}`);
+  }
+
+  const pv = toFloat32(pvBytes, pvMeta.descr, nLon * nLat * nMonths);
+  const lons = toFloat64(lonsBytes, lonsMeta.descr, nLon);
+  const lats = toFloat64(latsBytes, latsMeta.descr, nLat);
+
+  // The upstream `.npz` stores `lats` descending (north→south). Downstream
+  // code assumes ascending axes, so we flip in-place here: swap the lat axis
+  // in `lats` AND in `pv` (which indexes as [lon, lat, month] C-order).
+  // In-place is ~40 M float swaps for the current grid — fast and avoids a
+  // 300-MB peak allocation during load.
+  if (lons.length > 1 && lons[0] > lons[lons.length - 1]) reverseLons(pv, lons, nLon, nLat, nMonths);
+  if (lats.length > 1 && lats[0] > lats[lats.length - 1]) reverseLats(pv, lats, nLon, nLat, nMonths);
+
+  return { pv, lons, lats, nLon, nLat, nMonths };
+}
+
+function reverseLats(pv: Float32Array, lats: Float64Array, nLon: number, nLat: number, nMonths: number): void {
+  // Reverse lats in place.
+  for (let i = 0, j = nLat - 1; i < j; i++, j--) {
+    const t = lats[i];
+    lats[i] = lats[j];
+    lats[j] = t;
+  }
+  // For each (lon, month), swap the values at lat_idx and nLat-1-lat_idx.
+  const halfLat = Math.floor(nLat / 2);
+  for (let l = 0; l < nLon; l++) {
+    const lonBase = l * nLat;
+    for (let k = 0; k < halfLat; k++) {
+      const aBase = (lonBase + k) * nMonths;
+      const bBase = (lonBase + (nLat - 1 - k)) * nMonths;
+      for (let m = 0; m < nMonths; m++) {
+        const t = pv[aBase + m];
+        pv[aBase + m] = pv[bBase + m];
+        pv[bBase + m] = t;
+      }
+    }
+  }
+}
+
+function reverseLons(pv: Float32Array, lons: Float64Array, nLon: number, nLat: number, nMonths: number): void {
+  for (let i = 0, j = nLon - 1; i < j; i++, j--) {
+    const t = lons[i];
+    lons[i] = lons[j];
+    lons[j] = t;
+  }
+  const halfLon = Math.floor(nLon / 2);
+  const stride = nLat * nMonths;
+  for (let l = 0; l < halfLon; l++) {
+    const aBase = l * stride;
+    const bBase = (nLon - 1 - l) * stride;
+    for (let k = 0; k < stride; k++) {
+      const t = pv[aBase + k];
+      pv[aBase + k] = pv[bBase + k];
+      pv[bBase + k] = t;
+    }
+  }
+}
+
+// ── npy + zip internals ──────────────────────────────────────────────────────
+
+interface NpyMeta {
+  descr: string;                   // e.g. '<f4', '<f8'
+  fortran_order: boolean;
+  shape: number[];
+}
+
+function parseNpy(raw: Buffer): { meta: NpyMeta; data: Buffer } {
+  if (raw.length < 10 || raw.slice(0, 6).toString('latin1') !== '\x93NUMPY') {
+    throw new Error('not an .npy file (bad magic)');
+  }
+  const major = raw[6];
+  let headerLen: number;
+  let headerStart: number;
+  if (major === 1) {
+    headerLen = raw.readUInt16LE(8);
+    headerStart = 10;
+  } else if (major === 2) {
+    headerLen = raw.readUInt32LE(8);
+    headerStart = 12;
+  } else {
+    throw new Error(`unsupported .npy version ${major}`);
+  }
+
+  const headerStr = raw.slice(headerStart, headerStart + headerLen).toString('latin1').trim();
+  const meta = parsePythonDictLiteral(headerStr);
+  return {
+    meta: {
+      descr: meta.descr,
+      fortran_order: Boolean(meta.fortran_order),
+      shape: meta.shape,
+    },
+    data: raw.slice(headerStart + headerLen),
+  };
+}
+
+/**
+ * Parse the tiny Python-dict literal that npy headers carry. The grammar is
+ * restricted: keys are single-quoted strings; values are strings, bools,
+ * or a tuple of ints. We hand-roll a small tokenizer rather than eval() the
+ * string.
+ */
+function parsePythonDictLiteral(s: string): { descr: string; fortran_order: boolean; shape: number[] } {
+  const descr = s.match(/'descr'\s*:\s*'([^']+)'/)?.[1];
+  const fortranStr = s.match(/'fortran_order'\s*:\s*(True|False)/)?.[1];
+  const shapeStr = s.match(/'shape'\s*:\s*\(([^)]*)\)/)?.[1];
+  if (!descr || fortranStr === undefined || shapeStr === undefined) {
+    throw new Error(`.npy header unparseable: ${s}`);
+  }
+  const shape = shapeStr
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+    .map((t) => {
+      const n = Number(t);
+      if (!Number.isInteger(n)) throw new Error(`bad shape component: ${t}`);
+      return n;
+    });
+  return { descr, fortran_order: fortranStr === 'True', shape };
+}
+
+function assertNoFortran(meta: NpyMeta, name: string): void {
+  if (meta.fortran_order) {
+    throw new Error(`${name} is fortran-order; reader expects C-order`);
+  }
+}
+
+function toFloat32(buf: Buffer, descr: string, n: number): Float32Array {
+  if (descr === '<f4') {
+    if (buf.length < n * 4) throw new Error(`float32 buffer short: ${buf.length} < ${n * 4}`);
+    return new Float32Array(buf.buffer, buf.byteOffset, n);
+  }
+  if (descr === '<f8') {
+    if (buf.length < n * 8) throw new Error(`float64 buffer short: ${buf.length} < ${n * 8}`);
+    const src = new Float64Array(buf.buffer, buf.byteOffset, n);
+    const out = new Float32Array(n);
+    for (let i = 0; i < n; i++) out[i] = src[i];
+    return out;
+  }
+  throw new Error(`unsupported dtype for float32 target: ${descr}`);
+}
+
+function toFloat64(buf: Buffer, descr: string, n: number): Float64Array {
+  if (descr === '<f8') {
+    if (buf.length < n * 8) throw new Error(`float64 buffer short: ${buf.length} < ${n * 8}`);
+    return new Float64Array(buf.buffer, buf.byteOffset, n);
+  }
+  if (descr === '<f4') {
+    if (buf.length < n * 4) throw new Error(`float32 buffer short: ${buf.length} < ${n * 4}`);
+    const src = new Float32Array(buf.buffer, buf.byteOffset, n);
+    const out = new Float64Array(n);
+    for (let i = 0; i < n; i++) out[i] = src[i];
+    return out;
+  }
+  throw new Error(`unsupported dtype for float64 target: ${descr}`);
+}
+
+// ── minimal zip reader (deflate-or-stored only, no encryption, no zip64) ────
+
+function readZipEntries(zip: Buffer): Map<string, Buffer> {
+  // Find End of Central Directory (EOCD): last 22 bytes plus optional comment.
+  const EOCD_SIG = 0x06054b50;
+  let eocdOffset = -1;
+  for (let i = zip.length - 22; i >= Math.max(0, zip.length - 0xffff - 22); i--) {
+    if (zip.readUInt32LE(i) === EOCD_SIG) {
+      eocdOffset = i;
+      break;
+    }
+  }
+  if (eocdOffset < 0) throw new Error('zip: no End of Central Directory found');
+
+  const totalEntries = zip.readUInt16LE(eocdOffset + 10);
+  const cdSize = zip.readUInt32LE(eocdOffset + 12);
+  const cdOffset = zip.readUInt32LE(eocdOffset + 16);
+
+  const CFH_SIG = 0x02014b50;
+  const LFH_SIG = 0x04034b50;
+  const out = new Map<string, Buffer>();
+
+  let p = cdOffset;
+  for (let i = 0; i < totalEntries; i++) {
+    if (zip.readUInt32LE(p) !== CFH_SIG) {
+      throw new Error(`zip: bad central-file-header signature at ${p}`);
+    }
+    const compressionMethod = zip.readUInt16LE(p + 10);
+    const compressedSize = zip.readUInt32LE(p + 20);
+    const uncompressedSize = zip.readUInt32LE(p + 24);
+    const nameLen = zip.readUInt16LE(p + 28);
+    const extraLen = zip.readUInt16LE(p + 30);
+    const commentLen = zip.readUInt16LE(p + 32);
+    const localHeaderOffset = zip.readUInt32LE(p + 42);
+    const name = zip.slice(p + 46, p + 46 + nameLen).toString('utf8');
+
+    // Parse local file header to find the actual data offset.
+    if (zip.readUInt32LE(localHeaderOffset) !== LFH_SIG) {
+      throw new Error(`zip: bad local-file-header signature for ${name}`);
+    }
+    const lfhNameLen = zip.readUInt16LE(localHeaderOffset + 26);
+    const lfhExtraLen = zip.readUInt16LE(localHeaderOffset + 28);
+    const dataStart = localHeaderOffset + 30 + lfhNameLen + lfhExtraLen;
+    const dataEnd = dataStart + compressedSize;
+
+    let data: Buffer;
+    if (compressionMethod === 0) {
+      data = zip.slice(dataStart, dataEnd);
+    } else if (compressionMethod === 8) {
+      data = inflateRawSync(zip.slice(dataStart, dataEnd));
+    } else {
+      throw new Error(`zip: unsupported compression method ${compressionMethod} for ${name}`);
+    }
+    if (data.length !== uncompressedSize) {
+      throw new Error(
+        `zip: ${name} inflated size ${data.length} != expected ${uncompressedSize}`,
+      );
+    }
+    out.set(name, data);
+
+    p += 46 + nameLen + extraLen + commentLen;
+    if (p > cdOffset + cdSize) {
+      throw new Error('zip: central directory walk overran declared size');
+    }
+  }
+
+  return out;
+}

--- a/apps/drec-api/src/pods/solar-yield/solar-yield.module.ts
+++ b/apps/drec-api/src/pods/solar-yield/solar-yield.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SolarYieldService } from './solar-yield.service';
+
+@Module({
+  providers: [SolarYieldService],
+  exports: [SolarYieldService],
+})
+export class SolarYieldModule {}

--- a/apps/drec-api/src/pods/solar-yield/solar-yield.service.spec.ts
+++ b/apps/drec-api/src/pods/solar-yield/solar-yield.service.spec.ts
@@ -1,0 +1,180 @@
+import { SolarYieldService } from './solar-yield.service';
+import { SolarGrid } from './npz-reader';
+import { SOLAR_MODEL_CONFIG } from './config';
+
+/**
+ * Unit tests for the Kartik port. They avoid the real 311-MB grid by
+ * injecting a trivial synthetic grid where `interpolate(_, _, m) = m`,
+ * which lets us hand-compute every expected value.
+ */
+
+const { PF_avg: PF, DF, staticAvg, solarGsaVersion, linearRegressionVersion } =
+  SOLAR_MODEL_CONFIG;
+
+const DAYS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/**
+ * Build a 2×2×12 grid where pv_data[anyLon, anyLat, monthIdx] = monthIdx + 1.
+ * Any query at (lon∈[0,1], lat∈[0,1], month∈[1..12]) yields `month`.
+ */
+function makeIdentityGrid(): SolarGrid {
+  const nLon = 2;
+  const nLat = 2;
+  const nMonths = 12;
+  const pv = new Float32Array(nLon * nLat * nMonths);
+  for (let l = 0; l < nLon; l++) {
+    for (let k = 0; k < nLat; k++) {
+      for (let m = 0; m < nMonths; m++) {
+        pv[(l * nLat + k) * nMonths + m] = m + 1;
+      }
+    }
+  }
+  return {
+    pv,
+    lons: new Float64Array([0, 1]),
+    lats: new Float64Array([0, 1]),
+    nLon,
+    nLat,
+    nMonths,
+  };
+}
+
+function makeService(): SolarYieldService {
+  const svc = new SolarYieldService();
+  // Bypass onModuleInit to avoid touching the disk.
+  (svc as unknown as { grid: SolarGrid }).grid = makeIdentityGrid();
+  return svc;
+}
+
+describe('SolarYieldService', () => {
+  const svc = makeService();
+
+  describe('Case A (year > COD year)', () => {
+    it('returns a full 12-month vector scaled by PF, DF, capacity, and days-per-month', () => {
+      const capacity = 10;
+      const year = 2025;
+      const codYear = 2024;
+      const correction = PF * (1 - DF) ** (year - codYear);
+
+      const result = svc.getSolarEnergy(0, 0, capacity, '2024-01-01', year);
+
+      // With identity grid, monthly = correction * capacity * (month) * daysInMonth
+      const expectedMonthly = DAYS.map((d, i) => correction * capacity * (i + 1) * d);
+      const expectedYield = Math.round(expectedMonthly.reduce((s, v) => s + v, 0) * 100) / 100;
+
+      expect(result.Model_1_Outputs.Monthly_kWh).toHaveLength(12);
+      result.Model_1_Outputs.Monthly_kWh.forEach((v, i) => {
+        expect(v).toBeCloseTo(expectedMonthly[i], 6);
+      });
+      expect(result.Model_1_Outputs.Yield_kWh).toBeCloseTo(expectedYield, 2);
+      expect(result.Model_1_Outputs.Version).toBe(solarGsaVersion);
+
+      expect(result.Model_2_Outputs.Yield_kWh).toBeCloseTo(
+        correction * capacity * staticAvg,
+        6,
+      );
+      expect(result.Model_2_Outputs.Version).toBe(linearRegressionVersion);
+      expect(result.Model_2_Outputs.Static_Average).toBe(staticAvg);
+    });
+
+    it('applies the degradation factor per-year-past-COD', () => {
+      const y1 = svc.getSolarEnergy(0, 0, 1, '2024-01-01', 2025);
+      const y5 = svc.getSolarEnergy(0, 0, 1, '2024-01-01', 2029);
+      // Ratio equals (1 - DF)^4 because year-delta differs by 4.
+      // Yield_kWh is rounded to 2 decimals, so the ratio can drift by ~1e-6
+      // relative to the true DF^4 — 4-digit precision accepts that.
+      expect(y5.Model_1_Outputs.Yield_kWh / y1.Model_1_Outputs.Yield_kWh).toBeCloseTo(
+        (1 - DF) ** 4,
+        4,
+      );
+    });
+  });
+
+  describe('Case B (year == COD year)', () => {
+    it('uses relevantDaysVec, not days_vec[i], for the full-months loop (PR#1 fix 1)', () => {
+      // COD June 1, 2024 → partial June (30 days) + July..Dec full months.
+      // With identity grid, full-months part = Σ PF * cap * month * daysInMonth
+      // across months 7..12. If the Python bug were reintroduced (days_vec[i]
+      // starting at index 0), it would multiply July by 31, August by 28, etc.,
+      // which gives a detectably different total.
+      const capacity = 1;
+      const result = svc.getSolarEnergy(0, 0, capacity, '2024-06-01', 2024);
+
+      // Partial month: June has 30 days, COD day-of-month = 1, so partialDays = 30.
+      const partial = PF * capacity * 6 * 30;
+      const fullMonthsExpected =
+        PF * capacity * 7 * DAYS[6] + // July
+        PF * capacity * 8 * DAYS[7] + // August
+        PF * capacity * 9 * DAYS[8] + // September
+        PF * capacity * 10 * DAYS[9] + // October
+        PF * capacity * 11 * DAYS[10] + // November
+        PF * capacity * 12 * DAYS[11]; // December
+
+      const expectedTotal =
+        Math.round((partial + Math.round(fullMonthsExpected * 100) / 100) * 100) / 100;
+
+      expect(result.Model_1_Outputs.Yield_kWh).toBeCloseTo(expectedTotal, 2);
+
+      // Monthly_kWh: 12 entries, zeros for Jan..May, partial for June, then Jul..Dec.
+      expect(result.Model_1_Outputs.Monthly_kWh).toHaveLength(12);
+      for (let i = 0; i < 5; i++) expect(result.Model_1_Outputs.Monthly_kWh[i]).toBe(0);
+      expect(result.Model_1_Outputs.Monthly_kWh[5]).toBeCloseTo(partial, 6);
+      expect(result.Model_1_Outputs.Monthly_kWh[6]).toBeCloseTo(PF * capacity * 7 * DAYS[6], 6);
+      expect(result.Model_1_Outputs.Monthly_kWh[11]).toBeCloseTo(PF * capacity * 12 * DAYS[11], 6);
+    });
+
+    it('handles partial-month day count when COD is mid-month', () => {
+      // COD June 15, 2024 → partial June covers days 15..30 = 16 days.
+      const result = svc.getSolarEnergy(0, 0, 1, '2024-06-15', 2024);
+      const expectedPartial = PF * 1 * 6 * 16;
+      expect(result.Model_1_Outputs.Monthly_kWh[5]).toBeCloseTo(expectedPartial, 6);
+    });
+
+    it('handles December COD (no full months after)', () => {
+      // COD Dec 10, 2024 → only partial December; no full months.
+      const result = svc.getSolarEnergy(0, 0, 1, '2024-12-10', 2024);
+      const expectedPartial = PF * 1 * 12 * (31 - 10 + 1);
+      expect(result.Model_1_Outputs.Yield_kWh).toBeCloseTo(expectedPartial, 2);
+      // Only December has a non-zero slot.
+      for (let i = 0; i < 11; i++) expect(result.Model_1_Outputs.Monthly_kWh[i]).toBe(0);
+      expect(result.Model_1_Outputs.Monthly_kWh[11]).toBeCloseTo(expectedPartial, 6);
+    });
+
+    it('applies correction to Model 2 Case B (PR#1 fix 3)', () => {
+      // In Case B the DF exponent is zero, so correction collapses to PF_avg.
+      // Upstream (pre-PR#1) Case B was `capacity * staticAvg * daysElapsed/365`,
+      // i.e. no PF factor — which would produce a ~22% higher Model-2 estimate.
+      const capacity = 10;
+      const result = svc.getSolarEnergy(0, 0, capacity, '2024-06-01', 2024);
+
+      // daysElapsed = 30 (June partial) + 31+31+30+31+30+31 (Jul..Dec) = 30 + 184 = 214.
+      const daysElapsed = 30 + 31 + 31 + 30 + 31 + 30 + 31;
+      const expected = PF * capacity * staticAvg * (daysElapsed / 365);
+      expect(result.Model_2_Outputs.Yield_kWh).toBeCloseTo(expected, 6);
+
+      // Explicitly verify PF was applied (the upstream bug would produce this value).
+      const buggy = capacity * staticAvg * (daysElapsed / 365);
+      expect(result.Model_2_Outputs.Yield_kWh).not.toBeCloseTo(buggy, 0);
+    });
+  });
+
+  describe('pre-COD guard (PR#1 fix 2)', () => {
+    it('throws RangeError when querying a year before COD', () => {
+      expect(() => svc.getSolarEnergy(0, 0, 1, '2024-06-01', 2023)).toThrow(RangeError);
+    });
+
+    it('allows year == COD year and year > COD year', () => {
+      expect(() => svc.getSolarEnergy(0, 0, 1, '2024-06-01', 2024)).not.toThrow();
+      expect(() => svc.getSolarEnergy(0, 0, 1, '2024-06-01', 2025)).not.toThrow();
+    });
+  });
+
+  describe('out-of-bounds', () => {
+    it('returns 0-yield when lat/lon fall outside the grid (fill_value=0 parity)', () => {
+      // Query lat=90 (grid max is 1 in our synthetic fixture) → all months yield 0.
+      const result = svc.getSolarEnergy(90, 90, 1, '2024-01-01', 2025);
+      expect(result.Model_1_Outputs.Yield_kWh).toBe(0);
+      result.Model_1_Outputs.Monthly_kWh.forEach((v) => expect(v).toBe(0));
+    });
+  });
+});

--- a/apps/drec-api/src/pods/solar-yield/solar-yield.service.spec.ts
+++ b/apps/drec-api/src/pods/solar-yield/solar-yield.service.spec.ts
@@ -170,11 +170,16 @@ describe('SolarYieldService', () => {
   });
 
   describe('out-of-bounds', () => {
-    it('returns 0-yield when lat/lon fall outside the grid (fill_value=0 parity)', () => {
-      // Query lat=90 (grid max is 1 in our synthetic fixture) → all months yield 0.
-      const result = svc.getSolarEnergy(90, 90, 1, '2024-01-01', 2025);
-      expect(result.Model_1_Outputs.Yield_kWh).toBe(0);
-      result.Model_1_Outputs.Monthly_kWh.forEach((v) => expect(v).toBe(0));
+    it('throws RangeError when lat or lon falls outside the grid', () => {
+      // Synthetic grid covers lat∈[0,1], lon∈[0,1]; 90 is outside both axes.
+      expect(() => svc.getSolarEnergy(90, 90, 1, '2024-01-01', 2025)).toThrow(RangeError);
+      expect(() => svc.getSolarEnergy(0.5, 999, 1, '2024-01-01', 2025)).toThrow(RangeError);
+      expect(() => svc.getSolarEnergy(-1, 0.5, 1, '2024-01-01', 2025)).toThrow(RangeError);
+    });
+
+    it('accepts boundary coordinates', () => {
+      expect(() => svc.getSolarEnergy(0, 0, 1, '2024-01-01', 2025)).not.toThrow();
+      expect(() => svc.getSolarEnergy(1, 1, 1, '2024-01-01', 2025)).not.toThrow();
     });
   });
 });

--- a/apps/drec-api/src/pods/solar-yield/solar-yield.service.spec.ts
+++ b/apps/drec-api/src/pods/solar-yield/solar-yield.service.spec.ts
@@ -8,8 +8,13 @@ import { SOLAR_MODEL_CONFIG } from './config';
  * which lets us hand-compute every expected value.
  */
 
-const { PF_avg: PF, DF, staticAvg, solarGsaVersion, linearRegressionVersion } =
-  SOLAR_MODEL_CONFIG;
+const {
+  PF_avg: PF,
+  DF,
+  staticAvg,
+  solarGsaVersion,
+  linearRegressionVersion,
+} = SOLAR_MODEL_CONFIG;
 
 const DAYS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
@@ -59,8 +64,11 @@ describe('SolarYieldService', () => {
       const result = svc.getSolarEnergy(0, 0, capacity, '2024-01-01', year);
 
       // With identity grid, monthly = correction * capacity * (month) * daysInMonth
-      const expectedMonthly = DAYS.map((d, i) => correction * capacity * (i + 1) * d);
-      const expectedYield = Math.round(expectedMonthly.reduce((s, v) => s + v, 0) * 100) / 100;
+      const expectedMonthly = DAYS.map(
+        (d, i) => correction * capacity * (i + 1) * d,
+      );
+      const expectedYield =
+        Math.round(expectedMonthly.reduce((s, v) => s + v, 0) * 100) / 100;
 
       expect(result.Model_1_Outputs.Monthly_kWh).toHaveLength(12);
       result.Model_1_Outputs.Monthly_kWh.forEach((v, i) => {
@@ -83,10 +91,9 @@ describe('SolarYieldService', () => {
       // Ratio equals (1 - DF)^4 because year-delta differs by 4.
       // Yield_kWh is rounded to 2 decimals, so the ratio can drift by ~1e-6
       // relative to the true DF^4 — 4-digit precision accepts that.
-      expect(y5.Model_1_Outputs.Yield_kWh / y1.Model_1_Outputs.Yield_kWh).toBeCloseTo(
-        (1 - DF) ** 4,
-        4,
-      );
+      expect(
+        y5.Model_1_Outputs.Yield_kWh / y1.Model_1_Outputs.Yield_kWh,
+      ).toBeCloseTo((1 - DF) ** 4, 4);
     });
   });
 
@@ -111,23 +118,35 @@ describe('SolarYieldService', () => {
         PF * capacity * 12 * DAYS[11]; // December
 
       const expectedTotal =
-        Math.round((partial + Math.round(fullMonthsExpected * 100) / 100) * 100) / 100;
+        Math.round(
+          (partial + Math.round(fullMonthsExpected * 100) / 100) * 100,
+        ) / 100;
 
       expect(result.Model_1_Outputs.Yield_kWh).toBeCloseTo(expectedTotal, 2);
 
       // Monthly_kWh: 12 entries, zeros for Jan..May, partial for June, then Jul..Dec.
       expect(result.Model_1_Outputs.Monthly_kWh).toHaveLength(12);
-      for (let i = 0; i < 5; i++) expect(result.Model_1_Outputs.Monthly_kWh[i]).toBe(0);
+      for (let i = 0; i < 5; i++)
+        expect(result.Model_1_Outputs.Monthly_kWh[i]).toBe(0);
       expect(result.Model_1_Outputs.Monthly_kWh[5]).toBeCloseTo(partial, 6);
-      expect(result.Model_1_Outputs.Monthly_kWh[6]).toBeCloseTo(PF * capacity * 7 * DAYS[6], 6);
-      expect(result.Model_1_Outputs.Monthly_kWh[11]).toBeCloseTo(PF * capacity * 12 * DAYS[11], 6);
+      expect(result.Model_1_Outputs.Monthly_kWh[6]).toBeCloseTo(
+        PF * capacity * 7 * DAYS[6],
+        6,
+      );
+      expect(result.Model_1_Outputs.Monthly_kWh[11]).toBeCloseTo(
+        PF * capacity * 12 * DAYS[11],
+        6,
+      );
     });
 
     it('handles partial-month day count when COD is mid-month', () => {
       // COD June 15, 2024 → partial June covers days 15..30 = 16 days.
       const result = svc.getSolarEnergy(0, 0, 1, '2024-06-15', 2024);
       const expectedPartial = PF * 1 * 6 * 16;
-      expect(result.Model_1_Outputs.Monthly_kWh[5]).toBeCloseTo(expectedPartial, 6);
+      expect(result.Model_1_Outputs.Monthly_kWh[5]).toBeCloseTo(
+        expectedPartial,
+        6,
+      );
     });
 
     it('handles December COD (no full months after)', () => {
@@ -136,8 +155,12 @@ describe('SolarYieldService', () => {
       const expectedPartial = PF * 1 * 12 * (31 - 10 + 1);
       expect(result.Model_1_Outputs.Yield_kWh).toBeCloseTo(expectedPartial, 2);
       // Only December has a non-zero slot.
-      for (let i = 0; i < 11; i++) expect(result.Model_1_Outputs.Monthly_kWh[i]).toBe(0);
-      expect(result.Model_1_Outputs.Monthly_kWh[11]).toBeCloseTo(expectedPartial, 6);
+      for (let i = 0; i < 11; i++)
+        expect(result.Model_1_Outputs.Monthly_kWh[i]).toBe(0);
+      expect(result.Model_1_Outputs.Monthly_kWh[11]).toBeCloseTo(
+        expectedPartial,
+        6,
+      );
     });
 
     it('applies correction to Model 2 Case B (PR#1 fix 3)', () => {
@@ -160,26 +183,42 @@ describe('SolarYieldService', () => {
 
   describe('pre-COD guard (PR#1 fix 2)', () => {
     it('throws RangeError when querying a year before COD', () => {
-      expect(() => svc.getSolarEnergy(0, 0, 1, '2024-06-01', 2023)).toThrow(RangeError);
+      expect(() => svc.getSolarEnergy(0, 0, 1, '2024-06-01', 2023)).toThrow(
+        RangeError,
+      );
     });
 
     it('allows year == COD year and year > COD year', () => {
-      expect(() => svc.getSolarEnergy(0, 0, 1, '2024-06-01', 2024)).not.toThrow();
-      expect(() => svc.getSolarEnergy(0, 0, 1, '2024-06-01', 2025)).not.toThrow();
+      expect(() =>
+        svc.getSolarEnergy(0, 0, 1, '2024-06-01', 2024),
+      ).not.toThrow();
+      expect(() =>
+        svc.getSolarEnergy(0, 0, 1, '2024-06-01', 2025),
+      ).not.toThrow();
     });
   });
 
   describe('out-of-bounds', () => {
     it('throws RangeError when lat or lon falls outside the grid', () => {
       // Synthetic grid covers lat∈[0,1], lon∈[0,1]; 90 is outside both axes.
-      expect(() => svc.getSolarEnergy(90, 90, 1, '2024-01-01', 2025)).toThrow(RangeError);
-      expect(() => svc.getSolarEnergy(0.5, 999, 1, '2024-01-01', 2025)).toThrow(RangeError);
-      expect(() => svc.getSolarEnergy(-1, 0.5, 1, '2024-01-01', 2025)).toThrow(RangeError);
+      expect(() => svc.getSolarEnergy(90, 90, 1, '2024-01-01', 2025)).toThrow(
+        RangeError,
+      );
+      expect(() => svc.getSolarEnergy(0.5, 999, 1, '2024-01-01', 2025)).toThrow(
+        RangeError,
+      );
+      expect(() => svc.getSolarEnergy(-1, 0.5, 1, '2024-01-01', 2025)).toThrow(
+        RangeError,
+      );
     });
 
     it('accepts boundary coordinates', () => {
-      expect(() => svc.getSolarEnergy(0, 0, 1, '2024-01-01', 2025)).not.toThrow();
-      expect(() => svc.getSolarEnergy(1, 1, 1, '2024-01-01', 2025)).not.toThrow();
+      expect(() =>
+        svc.getSolarEnergy(0, 0, 1, '2024-01-01', 2025),
+      ).not.toThrow();
+      expect(() =>
+        svc.getSolarEnergy(1, 1, 1, '2024-01-01', 2025),
+      ).not.toThrow();
     });
   });
 });

--- a/apps/drec-api/src/pods/solar-yield/solar-yield.service.ts
+++ b/apps/drec-api/src/pods/solar-yield/solar-yield.service.ts
@@ -60,7 +60,9 @@ export class SolarYieldService implements OnModuleInit {
         `loaded solar grid: ${this.grid.nLon}×${this.grid.nLat}×${this.grid.nMonths} (${ms} ms)`,
       );
     } catch (e: any) {
-      this.logger.error(`failed to load solar grid from ${p}: ${e?.message || e}`);
+      this.logger.error(
+        `failed to load solar grid from ${p}: ${e?.message || e}`,
+      );
     }
   }
 
@@ -157,13 +159,17 @@ export class SolarYieldService implements OnModuleInit {
     const partialMonthDays = daysInCodMonth - codDate.getUTCDate() + 1;
 
     const specEnergyPartial = this.interpolate(longitude, latitude, month);
-    const partialMonthGen = PF_avg * capacity * specEnergyPartial * partialMonthDays;
+    const partialMonthGen =
+      PF_avg * capacity * specEnergyPartial * partialMonthDays;
 
     let fullMonthsVec: number[] = [];
     let fullMonthsGen = 0;
     let relevantDaysVec: number[] = [0];
     if (month < 12) {
-      const remainingMonths = Array.from({ length: 12 - month }, (_, i) => month + 1 + i);
+      const remainingMonths = Array.from(
+        { length: 12 - month },
+        (_, i) => month + 1 + i,
+      );
       const specEnergy = remainingMonths.map((m) =>
         this.interpolate(longitude, latitude, m),
       );
@@ -182,7 +188,9 @@ export class SolarYieldService implements OnModuleInit {
     // Pad zeros so the returned Monthly_kWh has 12 entries with the partial
     // month landing in its correct calendar slot.
     const codToEoyVec = [partialMonthGen, ...fullMonthsVec];
-    const padded = Array<number>(12 - codToEoyVec.length).fill(0).concat(codToEoyVec);
+    const padded = Array<number>(12 - codToEoyVec.length)
+      .fill(0)
+      .concat(codToEoyVec);
 
     // PR #1 fix (3): Model 2 Case B applies `correction` too. With year == codYear
     // the DF exponent is zero, so correction collapses to PF_avg.

--- a/apps/drec-api/src/pods/solar-yield/solar-yield.service.ts
+++ b/apps/drec-api/src/pods/solar-yield/solar-yield.service.ts
@@ -100,6 +100,24 @@ export class SolarYieldService implements OnModuleInit {
       );
     }
 
+    // Coordinate-bounds guard. Scipy's RegularGridInterpolator(fill_value=0)
+    // silently returns 0 for OOB queries — same as the Python reference. That
+    // conflates a legitimate zero (polar winter) with a typo'd coordinate, so
+    // we raise here instead and let callers decide how to surface "not
+    // covered by the grid" vs a modelled zero.
+    const g = this.grid;
+    if (
+      latitude < g.lats[0] ||
+      latitude > g.lats[g.nLat - 1] ||
+      longitude < g.lons[0] ||
+      longitude > g.lons[g.nLon - 1]
+    ) {
+      throw new RangeError(
+        `coordinates out of grid bounds: lat=${latitude} lon=${longitude}; ` +
+          `grid covers lat [${g.lats[0]}, ${g.lats[g.nLat - 1]}] lon [${g.lons[0]}, ${g.lons[g.nLon - 1]}].`,
+      );
+    }
+
     const { PF_avg, DF, staticAvg, solarGsaVersion, linearRegressionVersion } =
       SOLAR_MODEL_CONFIG;
 
@@ -190,31 +208,18 @@ export class SolarYieldService implements OnModuleInit {
   }
 
   /**
-   * Nearest-neighbour lookup into the 3D grid at (lon, lat, month), matching
-   * scipy.interpolate.RegularGridInterpolator(method='nearest', bounds_error=False,
-   * fill_value=0). Returns 0 for out-of-bounds queries (the Python default —
-   * see `solar-yield/README.md` for why this deserves to be replaced with a
-   * hard error later).
+   * Nearest-neighbour lookup into the 3D grid at (lon, lat, month). Assumes
+   * bounds have already been validated by the caller (`getSolarEnergy` does
+   * this once up-front). NaN grid values — which the upstream dataset uses
+   * over oceans — surface as 0, matching the Python reference.
    */
   private interpolate(lon: number, lat: number, month: number): number {
     const g = this.grid!;
-    if (
-      lon < g.lons[0] ||
-      lon > g.lons[g.nLon - 1] ||
-      lat < g.lats[0] ||
-      lat > g.lats[g.nLat - 1] ||
-      month < 1 ||
-      month > g.nMonths
-    ) {
-      return 0;
-    }
     const lonIdx = nearestIndex(g.lons, lon);
     const latIdx = nearestIndex(g.lats, lat);
     const monthIdx = month - 1;
     const flat = (lonIdx * g.nLat + latIdx) * g.nMonths + monthIdx;
     const v = g.pv[flat];
-    // The grid carries NaN over oceans; surface it as 0 to match Python's
-    // interpolator behaviour for this dataset.
     return Number.isFinite(v) ? v : 0;
   }
 }

--- a/apps/drec-api/src/pods/solar-yield/solar-yield.service.ts
+++ b/apps/drec-api/src/pods/solar-yield/solar-yield.service.ts
@@ -1,0 +1,240 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { readSolarGrid, SolarGrid } from './npz-reader';
+import { SOLAR_MODEL_CONFIG } from './config';
+
+/**
+ * TypeScript port of Kartik Naik's `solar-monthly-predictionModel`
+ * (prediction_model.py) — specifically the fix branch under review as
+ * KNaik1695/solar-monthly-predictionModel PR #1, which includes:
+ *
+ *   1. Correct days-vec indexing in the Case-B full-months loop
+ *      (`relevant_days_vec[i]`, not `days_vec[i]`).
+ *   2. A `ValueError` guard on pre-COD queries (`year < cod.year`).
+ *   3. The `correction = PF * (1 - DF)^(year - cod.year)` factor applied to
+ *      Model 2 Case B as well, so Model 2 is continuous across the COD-year
+ *      boundary (Case B collapses to PF since the DF exponent is zero).
+ *
+ * The model is a typical-year climatology over a lat/lon/month grid — it does
+ * not reflect actual weather in the queried year. Use it for past-generation
+ * confirmations against tolerance bands sized to absorb ±10–15% inter-annual
+ * variability, not as a ground-truth estimator.
+ */
+export interface SolarYieldResult {
+  Model_1_Outputs: {
+    Yield_kWh: number;
+    Monthly_kWh: number[];
+    Version: string;
+    Name: string;
+  };
+  Model_2_Outputs: {
+    Yield_kWh: number;
+    Version: string;
+    Static_Average: number;
+    Name: string;
+  };
+}
+
+const DAYS_VEC = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+@Injectable()
+export class SolarYieldService implements OnModuleInit {
+  private readonly logger = new Logger(SolarYieldService.name);
+  private grid: SolarGrid | null = null;
+
+  onModuleInit(): void {
+    // Fail lazily: if the grid file isn't provisioned we want the rest of
+    // drec-api to boot normally; only callers that hit getSolarEnergy() see
+    // the error. See README for how to provision the .npz.
+    const p = process.env.SOLAR_GRID_NPZ_PATH;
+    if (!p) {
+      this.logger.warn(
+        'SOLAR_GRID_NPZ_PATH not set — solar-yield service is inert. Any getSolarEnergy() call will throw.',
+      );
+      return;
+    }
+    const t0 = Date.now();
+    try {
+      this.grid = readSolarGrid(p);
+      const ms = Date.now() - t0;
+      this.logger.log(
+        `loaded solar grid: ${this.grid.nLon}×${this.grid.nLat}×${this.grid.nMonths} (${ms} ms)`,
+      );
+    } catch (e: any) {
+      this.logger.error(`failed to load solar grid from ${p}: ${e?.message || e}`);
+    }
+  }
+
+  /**
+   * Compute yearly + monthly yield (Wh-output aggregated per month) for a
+   * single site. Mirrors `SolarEnergyInterpolator.get_solar_energy` from
+   * the Python reference.
+   *
+   * @param latitude   decimal degrees, [-60, 65]
+   * @param longitude  decimal degrees, [-180, 180]
+   * @param capacity   nameplate AC capacity in kW
+   * @param cod        Commercial Operation Date (Date or parseable string)
+   * @param year       the year to predict yield for
+   */
+  getSolarEnergy(
+    latitude: number,
+    longitude: number,
+    capacity: number,
+    cod: Date | string,
+    year: number,
+  ): SolarYieldResult {
+    if (!this.grid) {
+      throw new Error(
+        'solar-yield: grid not loaded (SOLAR_GRID_NPZ_PATH unset or load failed). See apps/drec-api/src/pods/solar-yield/README.md.',
+      );
+    }
+    const codDate = cod instanceof Date ? cod : new Date(cod);
+    if (Number.isNaN(codDate.getTime())) {
+      throw new Error(`cod unparseable: ${cod}`);
+    }
+    const codYear = codDate.getUTCFullYear();
+
+    // PR #1 fix (2): loud failure for pre-COD queries instead of silent nonsense.
+    if (year < codYear) {
+      throw new RangeError(
+        `year (${year}) is before COD year (${codYear}); cannot predict yield prior to commissioning.`,
+      );
+    }
+
+    const { PF_avg, DF, staticAvg, solarGsaVersion, linearRegressionVersion } =
+      SOLAR_MODEL_CONFIG;
+
+    if (year !== codYear) {
+      // Case A: full-year yield (year strictly after COD year).
+      const specEnergy = Array.from({ length: 12 }, (_, i) =>
+        this.interpolate(longitude, latitude, i + 1),
+      );
+      const correction = PF_avg * (1 - DF) ** (year - codYear);
+      const monthly = specEnergy.map(
+        (e, i) => correction * capacity * e * DAYS_VEC[i],
+      );
+      const yieldKwh = round2(monthly.reduce((s, v) => s + v, 0));
+
+      // Model 2 (linear regression): same correction factor, static avg * capacity.
+      const model2Yield = correction * capacity * staticAvg;
+
+      return {
+        Model_1_Outputs: {
+          Yield_kWh: yieldKwh,
+          Monthly_kWh: monthly,
+          Version: solarGsaVersion,
+          Name: 'Solar GSA Model',
+        },
+        Model_2_Outputs: {
+          Yield_kWh: model2Yield,
+          Version: linearRegressionVersion,
+          Static_Average: staticAvg,
+          Name: 'Linear regression model',
+        },
+      };
+    }
+
+    // Case B: COD year — partial first month + whole months to end of year.
+    const month = codDate.getUTCMonth() + 1; // 1..12
+    const daysInCodMonth = DAYS_VEC[month - 1];
+    const partialMonthDays = daysInCodMonth - codDate.getUTCDate() + 1;
+
+    const specEnergyPartial = this.interpolate(longitude, latitude, month);
+    const partialMonthGen = PF_avg * capacity * specEnergyPartial * partialMonthDays;
+
+    let fullMonthsVec: number[] = [];
+    let fullMonthsGen = 0;
+    let relevantDaysVec: number[] = [0];
+    if (month < 12) {
+      const remainingMonths = Array.from({ length: 12 - month }, (_, i) => month + 1 + i);
+      const specEnergy = remainingMonths.map((m) =>
+        this.interpolate(longitude, latitude, m),
+      );
+      // days_vec slice matching remainingMonths (month+1 .. 12, 1-based → days_vec indices month .. 11)
+      relevantDaysVec = DAYS_VEC.slice(month, 12);
+      // PR #1 fix (1): use relevantDaysVec[i], not DAYS_VEC[i]. The upstream bug
+      // shifted day counts by `month` — a June COD multiplied July's specific
+      // energy by January's 31 days, August by February's 28, and so on.
+      fullMonthsVec = specEnergy.map(
+        (e, i) => PF_avg * capacity * e * relevantDaysVec[i],
+      );
+      fullMonthsGen = round2(fullMonthsVec.reduce((s, v) => s + v, 0));
+    }
+    const codToEoyTotal = round2(partialMonthGen + fullMonthsGen);
+
+    // Pad zeros so the returned Monthly_kWh has 12 entries with the partial
+    // month landing in its correct calendar slot.
+    const codToEoyVec = [partialMonthGen, ...fullMonthsVec];
+    const padded = Array<number>(12 - codToEoyVec.length).fill(0).concat(codToEoyVec);
+
+    // PR #1 fix (3): Model 2 Case B applies `correction` too. With year == codYear
+    // the DF exponent is zero, so correction collapses to PF_avg.
+    const correction = PF_avg * (1 - DF) ** (year - codYear);
+    const fullMonthDays = relevantDaysVec.reduce((s, v) => s + v, 0);
+    const daysElapsed = partialMonthDays + fullMonthDays;
+    const model2Yield = correction * capacity * staticAvg * (daysElapsed / 365);
+
+    return {
+      Model_1_Outputs: {
+        Yield_kWh: codToEoyTotal,
+        Monthly_kWh: padded,
+        Version: solarGsaVersion,
+        Name: 'Solar GSA Model',
+      },
+      Model_2_Outputs: {
+        Yield_kWh: model2Yield,
+        Version: linearRegressionVersion,
+        Static_Average: staticAvg,
+        Name: 'Linear regression model',
+      },
+    };
+  }
+
+  /**
+   * Nearest-neighbour lookup into the 3D grid at (lon, lat, month), matching
+   * scipy.interpolate.RegularGridInterpolator(method='nearest', bounds_error=False,
+   * fill_value=0). Returns 0 for out-of-bounds queries (the Python default —
+   * see `solar-yield/README.md` for why this deserves to be replaced with a
+   * hard error later).
+   */
+  private interpolate(lon: number, lat: number, month: number): number {
+    const g = this.grid!;
+    if (
+      lon < g.lons[0] ||
+      lon > g.lons[g.nLon - 1] ||
+      lat < g.lats[0] ||
+      lat > g.lats[g.nLat - 1] ||
+      month < 1 ||
+      month > g.nMonths
+    ) {
+      return 0;
+    }
+    const lonIdx = nearestIndex(g.lons, lon);
+    const latIdx = nearestIndex(g.lats, lat);
+    const monthIdx = month - 1;
+    const flat = (lonIdx * g.nLat + latIdx) * g.nMonths + monthIdx;
+    const v = g.pv[flat];
+    // The grid carries NaN over oceans; surface it as 0 to match Python's
+    // interpolator behaviour for this dataset.
+    return Number.isFinite(v) ? v : 0;
+  }
+}
+
+/** Nearest-neighbour index into a monotonically increasing grid. */
+function nearestIndex(grid: Float64Array, x: number): number {
+  // Binary search for the first index > x.
+  let lo = 0;
+  let hi = grid.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (grid[mid] <= x) lo = mid + 1;
+    else hi = mid;
+  }
+  // `lo` now points to the first element strictly greater than x, or grid.length.
+  if (lo === 0) return 0;
+  if (lo === grid.length) return grid.length - 1;
+  return x - grid[lo - 1] <= grid[lo] - x ? lo - 1 : lo;
+}
+
+function round2(x: number): number {
+  return Math.round(x * 100) / 100;
+}


### PR DESCRIPTION
TypeScript port of [KNaik1695/solar-monthly-predictionModel](https://github.com/KNaik1695/solar-monthly-predictionModel) (nearest-neighbour lookup over a GSA climatology grid), wired into the reviewer's production-ceiling check as an additive estimate alongside the existing lat-band heuristic.

## Port

- **Tracks the fix branch**, not upstream main. Upstream PR [#1](https://github.com/KNaik1695/solar-monthly-predictionModel/pull/1) fixes three bugs: days-vector indexing in Case B, a pre-COD guard, and the correction factor applied to Model 2 Case B. The TS port has all three from day one; comments in the service point at each fix.
- **Stdlib-only \`.npz\` reader** (\`npz-reader.ts\`) — no new deps. Parses ZIP + inflateRaw + the numpy v1 header manually. Canonicalises axes to ascending at load (the upstream \`.npz\` stores lats descending).
- **Out-of-bounds coords throw \`RangeError\`**. Diverges from scipy's \`fill_value=0\` default so callers can distinguish a typo'd coordinate from a legitimate zero.
- **73-MB \`.npz\` is NOT committed.** Path comes from env var \`SOLAR_GRID_NPZ_PATH\`. If unset, service boots inert with a warning and throws only if \`getSolarEnergy()\` is called — keeps the rest of drec-api bootable in dev without provisioning the file. See \`apps/drec-api/src/pods/solar-yield/README.md\`.

## Wiring

Added a \`solarGsa\` field to the response of \`GET /device-reviews/:deviceId/production-ceiling\`:

\`\`\`ts
solarGsa: { annualKwh, monthlyKwh, version } | null
\`\`\`

\`irradiance\` (the lat-band lookup) is unchanged — the existing ceiling formula, \`yieldMismatch\` flag, and per-reading \`exceedsCeiling\` calculations still use it. The new field is additive for reviewers to compare against. Once the GSA estimate is validated in practice, a follow-up PR can retire the lat-band fallback and tighten the ceiling.

\`solarGsa\` is \`null\` when: grid file not provisioned, device missing lat/lon/capacity/COD, device is pre-COD, or coordinates are OOB.

## Tests

10/10 unit tests using a synthetic identity grid — no need to ship the 73-MB \`.npz\` to CI. Explicit coverage for each PR #1 fix, both case branches, mid-month/December COD, OOB throw, and boundary accepts.

Smoke-verified against the real \`.npz\` using Kartik's README example (\`lat=19.745365, lon=105.901337, cap=29.25, cod=2024-06-01, year=2025\`) — output matches the Python reference byte-identically (\`26992.39\` / \`34416.93\`).

## Known caveats documented in the README

- Typical-year climatology, not weather-corrected. Tolerance bands need to absorb ±10–15% inter-annual variability.
- Nearest-neighbour at ~9 km grid resolution — sites within a few km may resolve to the same cell.
- Model 2 is a \`capacity × static-avg × PF\` baseline; kept for parity with the Python output shape.

## Open follow-up

Peter has emailed Kartik asking if we can re-host the \`.npz\` on our S3 and what attribution to carry. Once that comes back, we'll pick between a public S3 URL or a private-bucket + init-container pattern. This PR doesn't commit to either.