### PR TITLE
docs: fix 6 pre-existing markdownlint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Repository for Origin DREC project
 ## Tech Stack
 
 **Backend** ([drec-origin](https://github.com/d-rec/drec-origin))
+
 - NestJS 8 / TypeORM / TypeScript
 - PostgreSQL / Redis / MinIO (S3-compatible)
 - Energy Web / Ethers.js (blockchain certificates)
@@ -41,6 +42,7 @@ Repository for Origin DREC project
 - Sentry (error monitoring)
 
 **Frontend** ([drec-ui](https://github.com/d-rec/drec-ui))
+
 - Angular 19 / Angular Material
 - Bootstrap 5
 - TypeScript 5.7 / SCSS
@@ -176,6 +178,7 @@ Paste the output values into your `.env`. This is fine for local development —
 3. Fund your wallet with test tokens at <https://voltafaucet.energyweb.org/>.
 4. Export your private key: **Account details → Show private key**.
 5. Update `.env`:
+
    ```ini
    ISSUER_PRIVATE_KEY=<private-key-without-0x-prefix>
    DREC_BLOCKCHAIN_ADDRESS=<your-wallet-address>

--- a/powertrust_readme.md
+++ b/powertrust_readme.md
@@ -177,7 +177,7 @@ new Redis({
 Kubernetes **automatically injects** environment variables for every Service
 in the same namespace. When a Service is named `redis`, the pod gets:
 
-```
+```text
 REDIS_PORT=tcp://10.100.150.81:6379
 REDIS_SERVICE_PORT=6379
 REDIS_SERVICE_HOST=10.100.150.81
@@ -195,7 +195,7 @@ named `redis` in the `stage` namespace, stage will break the same way.**
 
 `package.json` at `b80bf934` defines:
 
-```
+```text
 typeorm => ts-node -r tsconfig-paths/register node_modules/typeorm/cli.js --config ormconfig-dev.ts
 ```
 
@@ -203,7 +203,7 @@ which points at a **TypeScript** config file (`ormconfig-dev.ts`) and uses
 ts-node. After `pnpm prune --prod`, `@types/node` is gone, and ts-node fails
 with:
 
-```
+```text
 ormconfig-dev.ts(7,10): error TS2591: Cannot find name 'process'.
 ```
 


### PR DESCRIPTION
Unblocks the markdownlint CI check on every drec-origin PR — these errors are pre-existing on \`develop\`, not introduced by any specific PR.

## Fixes

- \`README.md\`: two \`MD032/blanks-around-lists\` (Backend + Frontend tech-stack lists need a blank line before the first \`- \`).
- \`README.md\`: one \`MD031/blanks-around-fences\` (the \`.env\` setup code block inside the numbered-list item needs a blank line before the fence).
- \`powertrust_readme.md\`: three \`MD040/fenced-code-language\` (env output, shell output, TS compiler output — all marked as \`text\`).

Content unchanged; only whitespace + code-fence language tags.