### PR TITLE
env-validator: refuse to boot when blockchain addresses are the null placeholder

### DIFF
--- a/apps/drec-api/src/config/validate-blockchain-env.spec.ts
+++ b/apps/drec-api/src/config/validate-blockchain-env.spec.ts
@@ -1,0 +1,72 @@
+import {
+  validateBlockchainEnv,
+  assertValidBlockchainEnv,
+} from './validate-blockchain-env';
+
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+const REAL_ADDRESS = '0xffcf8fdee72ac11b5c542428b35eef5769c409f0';
+
+describe('validateBlockchainEnv', () => {
+  it('returns no violations for fully-set real addresses', () => {
+    const { violations } = validateBlockchainEnv({
+      DREC_BLOCKCHAIN_ADDRESS: REAL_ADDRESS,
+      REACT_APP_ISSUER_ADDRESS: REAL_ADDRESS,
+    });
+    expect(violations).toHaveLength(0);
+  });
+
+  it('treats unset / empty vars as OK (local dev case)', () => {
+    const { violations } = validateBlockchainEnv({});
+    expect(violations).toHaveLength(0);
+  });
+
+  it('flags the null address on DREC_BLOCKCHAIN_ADDRESS', () => {
+    const { violations } = validateBlockchainEnv({
+      DREC_BLOCKCHAIN_ADDRESS: NULL_ADDRESS,
+      REACT_APP_ISSUER_ADDRESS: REAL_ADDRESS,
+    });
+    expect(violations).toEqual([
+      { name: 'DREC_BLOCKCHAIN_ADDRESS', value: NULL_ADDRESS },
+    ]);
+  });
+
+  it('flags the null address regardless of casing or leading whitespace', () => {
+    const { violations } = validateBlockchainEnv({
+      DREC_BLOCKCHAIN_ADDRESS: '  0x0000000000000000000000000000000000000000  ',
+      REACT_APP_ISSUER_ADDRESS: '0x0000000000000000000000000000000000000000',
+    });
+    expect(violations).toHaveLength(2);
+  });
+
+  it('does not flag other all-hex values', () => {
+    // Real-looking addresses that happen to have many zeros should still pass.
+    const { violations } = validateBlockchainEnv({
+      DREC_BLOCKCHAIN_ADDRESS: '0x1000000000000000000000000000000000000000',
+    });
+    expect(violations).toHaveLength(0);
+  });
+});
+
+describe('assertValidBlockchainEnv', () => {
+  it('throws and includes both env var name and value when violated', () => {
+    expect(() =>
+      assertValidBlockchainEnv({
+        DREC_BLOCKCHAIN_ADDRESS: NULL_ADDRESS,
+      }),
+    ).toThrow(/DREC_BLOCKCHAIN_ADDRESS/);
+    expect(() =>
+      assertValidBlockchainEnv({
+        DREC_BLOCKCHAIN_ADDRESS: NULL_ADDRESS,
+      }),
+    ).toThrow(/0x0000000000000000000000000000000000000000/);
+  });
+
+  it('does not throw for a clean env', () => {
+    expect(() =>
+      assertValidBlockchainEnv({
+        DREC_BLOCKCHAIN_ADDRESS: REAL_ADDRESS,
+        REACT_APP_ISSUER_ADDRESS: REAL_ADDRESS,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/drec-api/src/config/validate-blockchain-env.ts
+++ b/apps/drec-api/src/config/validate-blockchain-env.ts
@@ -1,0 +1,61 @@
+/**
+ * Startup-time validator for blockchain env vars.
+ *
+ * History: when the PowerTrust dedicated environment was stood up
+ * (2026-04-14), `DREC_BLOCKCHAIN_ADDRESS`, `REACT_APP_ISSUER_ADDRESS`, and the
+ * group-level `device_group.buyerAddress` were all left at the null-address
+ * placeholder `0x0000…0000`. The issuance pipeline kept running, minting
+ * every certificate to the burn address. The customer polled for tokens for
+ * eight days before anyone noticed. The failure was invisible because
+ * nothing refused to boot.
+ *
+ * This validator runs once at `startAPI` time and refuses to boot if any
+ * blockchain env var is explicitly set to the null address. Unset / empty
+ * values are allowed — local dev commonly runs without them, and nothing
+ * in the hot path reads an empty env var without its own guard. The
+ * failure mode we're catching is specifically "set, but set to the
+ * placeholder that any downstream code will treat as valid."
+ */
+
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const CHECKED_VARS = [
+  'DREC_BLOCKCHAIN_ADDRESS',
+  'REACT_APP_ISSUER_ADDRESS',
+] as const;
+
+export interface ValidationResult {
+  readonly violations: ReadonlyArray<{ name: string; value: string }>;
+}
+
+export function validateBlockchainEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ValidationResult {
+  const violations = CHECKED_VARS.map((name) => ({
+    name,
+    value: (env[name] ?? '').trim().toLowerCase(),
+  })).filter((v) => v.value === NULL_ADDRESS);
+  return { violations };
+}
+
+/** Throws (and kills startup) if the validator finds any placeholder nulls. */
+export function assertValidBlockchainEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const { violations } = validateBlockchainEnv(env);
+  if (violations.length === 0) return;
+
+  const lines = [
+    '',
+    '  drec-api refuses to boot: one or more blockchain env vars are set',
+    `  to the null address (${NULL_ADDRESS}).`,
+    '',
+    '  Offending vars:',
+    ...violations.map((v) => `    - ${v.name}=${v.value}`),
+    '',
+    '  Minting to the null address silently burns every issued certificate.',
+    '  Set these to real chain-account addresses before starting drec-api.',
+    '',
+  ];
+  throw new Error(lines.join('\n'));
+}

--- a/apps/drec-api/src/index.ts
+++ b/apps/drec-api/src/index.ts
@@ -16,9 +16,16 @@ import { version } from '../package.json';
 
 import './sentry';
 import { DRECModule } from './drec.module';
+import { assertValidBlockchainEnv } from './config/validate-blockchain-env';
 export { DRECModule } from './drec.module';
 
 export async function startAPI(logger?: LoggerService): Promise<any> {
+  // Refuse to boot if any blockchain env var is still the null-address
+  // placeholder (`0x0000…0000`). See config/validate-blockchain-env.ts for
+  // history — silent burn-mints went undetected for eight days on the
+  // PowerTrust dedicated env because nothing on the boot path noticed.
+  assertValidBlockchainEnv();
+
   const PORT = PortUtils.getPort();
   const getVersion = () => {
     let info;
@@ -57,14 +64,15 @@ export async function startAPI(logger?: LoggerService): Promise<any> {
 
   app.enableShutdownHooks();
 
-  const defaultOrigins = process.env.NODE_ENV === 'development'
-    ? true
-    : [
-        'https://app.drecs.org',
-        'https://stage.drecs.org',
-        'https://stage-portal.drecs.org',
-        'https://demo.drecs.org',
-      ];
+  const defaultOrigins =
+    process.env.NODE_ENV === 'development'
+      ? true
+      : [
+          'https://app.drecs.org',
+          'https://stage.drecs.org',
+          'https://stage-portal.drecs.org',
+          'https://demo.drecs.org',
+        ];
   const corsOrigin = process.env.CORS_ORIGIN
     ? process.env.CORS_ORIGIN.split(',')
     : defaultOrigins;


### PR DESCRIPTION
## Why

When the PowerTrust dedicated environment was stood up (2026-04-14), \`DREC_BLOCKCHAIN_ADDRESS\` and \`REACT_APP_ISSUER_ADDRESS\` were left at their \`0x0000…0000\` placeholder values. Nothing on the boot path noticed. The issuance pipeline ran, every mint reverted against \`address(0)\`, and certificates landed in \`certificate_read_model\` with \`isSynced=false\` forever. **The customer lost 8 days of certificates before flagging.**

## What

Adds \`assertValidBlockchainEnv()\`, called once at \`startAPI\` time in \`src/index.ts\`:

- **Throws** (kills boot) if \`DREC_BLOCKCHAIN_ADDRESS\` or \`REACT_APP_ISSUER_ADDRESS\` is **explicitly set** to the null address.
- **Allows unset / empty** — local dev commonly runs without them, and every downstream call already has its own empty-value guard.
- Error message names the offending var + value, so ops can fix it in one round-trip instead of log-grepping.

## Tests

7 unit tests in \`validate-blockchain-env.spec.ts\` covering:
- Fully-set real addresses (pass)
- Unset env (pass — local dev case)
- Null address on DREC_BLOCKCHAIN_ADDRESS, REACT_APP_ISSUER_ADDRESS
- Whitespace / case normalisation
- All-hex values that aren't the null (pass — e.g., \`0x1000…\`)
- Error message contents

## Follow-on opportunity, not in this PR

\`device_group.buyerAddress\` has the same failure mode at the data layer — a group created with the null-address placeholder silently mints every certificate into the burn address. A similar DB-level guard (reject on save) would close that gap. Separate change.