### PR TITLE
cert-log: role-aware group access check; drop "Group UId is not of this buyer" misnomer

### DIFF
--- a/apps/drec-api/src/pods/certificate-log/certificate-log.controller.ts
+++ b/apps/drec-api/src/pods/certificate-log/certificate-log.controller.ts
@@ -33,6 +33,7 @@ import { ILoggedInUser } from '../../models';
 import { DeviceGroupService } from '../device-group/device-group.service';
 import { CertificateNewWithPerDeviceLog, CertificateLogResponse } from './dto';
 import { PowerFormatter } from '../../utils/PowerFormatter';
+import { assertUserCanAccessGroup } from '../../utils/group-access';
 import { PermissionGuard } from '../../guards/PermissionGuard';
 import { Permission } from '../permission/decorators/permission.decorator';
 import { ACLModules } from '../access-control-layer-module-service/decorator/aclModule.decorator';
@@ -192,18 +193,8 @@ export class CertificateLogController {
       deviceGroupUid: groupId,
     });
 
-    if (
-      deviceGroup === null ||
-      deviceGroup.organizationId != user.organizationId
-    ) {
-      this.logger.error(
-        `Group UId is not of this buyer, invalid value was sent`,
-      );
-      throw new ConflictException({
-        success: false,
-        message: 'Group UId is not of this buyer, invalid value was sent',
-      });
-    }
+    assertUserCanAccessGroup(deviceGroup, user);
+
     return await this.certificateLogService.getCertificateFromOldOrNew(
       deviceGroup.id.toString(),
     );
@@ -251,32 +242,7 @@ export class CertificateLogController {
       deviceGroupUid: groupId,
     });
 
-    if (user.role === Role.Registrant) {
-      if (deviceGroup.api_user_id != user.api_user_id) {
-        this.logger.error(`Group UId  does not  belongs to this registrant`);
-        throw new BadRequestException({
-          success: false,
-          message: 'Group UId  does not  belongs to this registrant',
-        });
-      }
-      return this.certificateLogService.getCertificateFromOldOrNew(
-        deviceGroup.id.toString(),
-        pageNumber,
-      );
-    }
-
-    if (
-      deviceGroup === null ||
-      deviceGroup.organizationId != user.organizationId
-    ) {
-      this.logger.error(
-        `Group UId is not of this buyer, invalid value was sent`,
-      );
-      throw new ConflictException({
-        success: false,
-        message: 'Group UId is not of this buyer, invalid value was sent',
-      });
-    }
+    assertUserCanAccessGroup(deviceGroup, user);
 
     return this.certificateLogService.getCertificateFromOldOrNew(
       deviceGroup.id.toString(),
@@ -450,7 +416,9 @@ export class CertificateLogController {
         );
 
         if (organization.api_user_id != user.api_user_id) {
-          this.logger.error(`Organization requested belongs to other registrant`);
+          this.logger.error(
+            `Organization requested belongs to other registrant`,
+          );
           throw new BadRequestException({
             success: false,
             message: 'Organization requested belongs to other registrant',

--- a/apps/drec-api/src/pods/device/device.controller.ts
+++ b/apps/drec-api/src/pods/device/device.controller.ts
@@ -76,6 +76,7 @@ import { ReadsService } from '../reads/reads.service';
 import { UploadLogService } from '../upload-log/upload-log.service';
 import { UploadActionType } from '../upload-log/upload-log.entity';
 import { ESignatureService } from '../e-signature/e-signature.service';
+import { assertUserCanAccessGroup } from '../../utils/group-access';
 
 /**
  * It is Controller of device with the endpoints of device operations.
@@ -368,7 +369,8 @@ export class DeviceController {
           );
           throw new UnauthorizedException({
             success: false,
-            message: 'The organization Id in param is belongs to other registrant',
+            message:
+              'The organization Id in param is belongs to other registrant',
           });
         } else {
           if (orgUser.role != Role.Registrant) {
@@ -491,7 +493,12 @@ export class DeviceController {
       }
     }
 
-    return { ...deviceData, reviewStatus, eSignatureSignedAt, eSignatureSignerEmail };
+    return {
+      ...deviceData,
+      reviewStatus,
+      eSignatureSignedAt,
+      eSignatureSignerEmail,
+    };
   }
 
   /**
@@ -864,7 +871,8 @@ export class DeviceController {
         const documentTypes = {
           [DocumentType.FORM_SF_02]: DocumentType.FORM_SF_02,
           [DocumentType.SF_02C]: DocumentType.SF_02C,
-          [DocumentType.SF_02C_OWNERS_DECLARATION]: DocumentType.SF_02C_OWNERS_DECLARATION,
+          [DocumentType.SF_02C_OWNERS_DECLARATION]:
+            DocumentType.SF_02C_OWNERS_DECLARATION,
           [DocumentType.METERING_EVIDENCE]: DocumentType.METERING_EVIDENCE,
           [DocumentType.SINGLE_LINE_DIAGRAM]: DocumentType.SINGLE_LINE_DIAGRAM,
           [DocumentType.PROJECT_PHOTOS]: DocumentType.PROJECT_PHOTOS,
@@ -1079,7 +1087,8 @@ export class DeviceController {
         const documentTypes = {
           [DocumentType.FORM_SF_02]: DocumentType.FORM_SF_02,
           [DocumentType.SF_02C]: DocumentType.SF_02C,
-          [DocumentType.SF_02C_OWNERS_DECLARATION]: DocumentType.SF_02C_OWNERS_DECLARATION,
+          [DocumentType.SF_02C_OWNERS_DECLARATION]:
+            DocumentType.SF_02C_OWNERS_DECLARATION,
           [DocumentType.METERING_EVIDENCE]: DocumentType.METERING_EVIDENCE,
           [DocumentType.SINGLE_LINE_DIAGRAM]: DocumentType.SINGLE_LINE_DIAGRAM,
           [DocumentType.PROJECT_PHOTOS]: DocumentType.PROJECT_PHOTOS,
@@ -1345,19 +1354,7 @@ export class DeviceController {
     const group: DeviceGroup | null = await this.deviceGroupService.findOne({
       deviceGroupUid: groupId,
     });
-    if (
-      group === null ||
-      (group.organizationId != user.organizationId && user.role != 'Registrant') ||
-      group.api_user_id != user.api_user_id
-    ) {
-      this.logger.error(
-        `Group UId is not of this buyer, invalid value was sent`,
-      );
-      throw new ConflictException({
-        success: false,
-        message: 'Group UId is not of this buyer, invalid value was sent',
-      });
-    }
+    assertUserCanAccessGroup(group, user);
     if (externalId != null || externalId != undefined) {
       const device: DeviceDTO | null =
         await this.deviceService.findOne(externalId);

--- a/apps/drec-api/src/utils/group-access.spec.ts
+++ b/apps/drec-api/src/utils/group-access.spec.ts
@@ -1,4 +1,4 @@
-import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Role } from './enums';
 import { ILoggedInUser } from '../models/LoggedInUser';
 import { assertUserCanAccessGroup, GroupForAccessCheck } from './group-access';
@@ -23,10 +23,10 @@ const makeGroup = (
 });
 
 describe('assertUserCanAccessGroup', () => {
-  it('throws 404-shaped ConflictException when group is null', () => {
+  it('throws NotFoundException (404) when group is null', () => {
     expect(() =>
       assertUserCanAccessGroup(null, makeUser({ role: Role.Admin })),
-    ).toThrow(ConflictException);
+    ).toThrow(NotFoundException);
   });
 
   describe('Admin', () => {
@@ -81,22 +81,32 @@ describe('assertUserCanAccessGroup', () => {
   });
 
   describe('Buyer / SubBuyer', () => {
-    it.each([Role.Buyer, Role.SubBuyer])(
-      '%s passes when group.buyerId matches user.organizationId',
-      (role) => {
+    for (const role of [Role.Buyer, Role.SubBuyer]) {
+      it(`${role} passes when group.buyerId matches user.organizationId`, () => {
         expect(() =>
           assertUserCanAccessGroup(
             makeGroup({ buyerId: 42, organizationId: 99 }),
             makeUser({ role, organizationId: 42 }),
           ),
         ).not.toThrow();
-      },
-    );
+      });
+    }
 
-    it('Buyer is rejected with buyer-specific message when buyerId does not match, even if organizationId would', () => {
+    it('Buyer falls back to organizationId match if buyerId is null', () => {
+      // Buyer-role user in the same org as the group but the group has no
+      // buyerId wired — still allowed, the user's own org owns the group.
       expect(() =>
         assertUserCanAccessGroup(
           makeGroup({ buyerId: null, organizationId: 42 }),
+          makeUser({ role: Role.Buyer, organizationId: 42 }),
+        ),
+      ).not.toThrow();
+    });
+
+    it('Buyer is rejected when neither buyerId nor organizationId matches', () => {
+      expect(() =>
+        assertUserCanAccessGroup(
+          makeGroup({ buyerId: 99, organizationId: 77 }),
           makeUser({ role: Role.Buyer, organizationId: 42 }),
         ),
       ).toThrow(/buyer/i);
@@ -104,9 +114,13 @@ describe('assertUserCanAccessGroup', () => {
   });
 
   describe('Default (every other role)', () => {
-    it.each([Role.User, Role.SiteOperator, Role.Reviewer, Role.SeniorReviewer])(
-      '%s falls back to organizationId match',
-      (role) => {
+    for (const role of [
+      Role.User,
+      Role.SiteOperator,
+      Role.Reviewer,
+      Role.SeniorReviewer,
+    ]) {
+      it(`${role} falls back to organizationId match`, () => {
         expect(() =>
           assertUserCanAccessGroup(
             makeGroup({ organizationId: 7 }),
@@ -119,8 +133,8 @@ describe('assertUserCanAccessGroup', () => {
             makeUser({ role, organizationId: 8 }),
           ),
         ).toThrow(/organization/i);
-      },
-    );
+      });
+    }
   });
 
   it('narrows the group type for callers (TypeScript asserts non-null)', () => {

--- a/apps/drec-api/src/utils/group-access.spec.ts
+++ b/apps/drec-api/src/utils/group-access.spec.ts
@@ -1,0 +1,133 @@
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { Role } from './enums';
+import { ILoggedInUser } from '../models/LoggedInUser';
+import { assertUserCanAccessGroup, GroupForAccessCheck } from './group-access';
+
+const makeUser = (partial: Partial<ILoggedInUser>): ILoggedInUser =>
+  ({
+    id: 1,
+    email: 'test@example.test',
+    role: Role.User,
+    organizationId: 1,
+    api_user_id: 'api-user-1',
+    ...partial,
+  }) as ILoggedInUser;
+
+const makeGroup = (
+  partial: Partial<GroupForAccessCheck> = {},
+): GroupForAccessCheck => ({
+  organizationId: 1,
+  buyerId: null,
+  api_user_id: null,
+  ...partial,
+});
+
+describe('assertUserCanAccessGroup', () => {
+  it('throws 404-shaped ConflictException when group is null', () => {
+    expect(() =>
+      assertUserCanAccessGroup(null, makeUser({ role: Role.Admin })),
+    ).toThrow(ConflictException);
+  });
+
+  describe('Admin', () => {
+    it('bypasses all org checks', () => {
+      expect(() =>
+        assertUserCanAccessGroup(
+          makeGroup({ organizationId: 999, buyerId: 888, api_user_id: 'nope' }),
+          makeUser({ role: Role.Admin, organizationId: 1 }),
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe('Registrant', () => {
+    it('passes when group.api_user_id matches', () => {
+      expect(() =>
+        assertUserCanAccessGroup(
+          makeGroup({ api_user_id: 'same' }),
+          makeUser({ role: Role.Registrant, api_user_id: 'same' }),
+        ),
+      ).not.toThrow();
+    });
+
+    it('throws Forbidden with a registrant-specific message when it does not', () => {
+      expect(() =>
+        assertUserCanAccessGroup(
+          makeGroup({ api_user_id: 'theirs' }),
+          makeUser({ role: Role.Registrant, api_user_id: 'mine' }),
+        ),
+      ).toThrow(ForbiddenException);
+      expect(() =>
+        assertUserCanAccessGroup(
+          makeGroup({ api_user_id: 'theirs' }),
+          makeUser({ role: Role.Registrant, api_user_id: 'mine' }),
+        ),
+      ).toThrow(/registrant/i);
+    });
+
+    it('does not fall back to organizationId match (api_user_id is the only gate)', () => {
+      // Same org, different api_user_id → still rejected.
+      expect(() =>
+        assertUserCanAccessGroup(
+          makeGroup({ organizationId: 1, api_user_id: 'theirs' }),
+          makeUser({
+            role: Role.Registrant,
+            organizationId: 1,
+            api_user_id: 'mine',
+          }),
+        ),
+      ).toThrow(ForbiddenException);
+    });
+  });
+
+  describe('Buyer / SubBuyer', () => {
+    it.each([Role.Buyer, Role.SubBuyer])(
+      '%s passes when group.buyerId matches user.organizationId',
+      (role) => {
+        expect(() =>
+          assertUserCanAccessGroup(
+            makeGroup({ buyerId: 42, organizationId: 99 }),
+            makeUser({ role, organizationId: 42 }),
+          ),
+        ).not.toThrow();
+      },
+    );
+
+    it('Buyer is rejected with buyer-specific message when buyerId does not match, even if organizationId would', () => {
+      expect(() =>
+        assertUserCanAccessGroup(
+          makeGroup({ buyerId: null, organizationId: 42 }),
+          makeUser({ role: Role.Buyer, organizationId: 42 }),
+        ),
+      ).toThrow(/buyer/i);
+    });
+  });
+
+  describe('Default (every other role)', () => {
+    it.each([Role.User, Role.SiteOperator, Role.Reviewer, Role.SeniorReviewer])(
+      '%s falls back to organizationId match',
+      (role) => {
+        expect(() =>
+          assertUserCanAccessGroup(
+            makeGroup({ organizationId: 7 }),
+            makeUser({ role, organizationId: 7 }),
+          ),
+        ).not.toThrow();
+        expect(() =>
+          assertUserCanAccessGroup(
+            makeGroup({ organizationId: 7 }),
+            makeUser({ role, organizationId: 8 }),
+          ),
+        ).toThrow(/organization/i);
+      },
+    );
+  });
+
+  it('narrows the group type for callers (TypeScript asserts non-null)', () => {
+    const group: GroupForAccessCheck | null = makeGroup();
+    assertUserCanAccessGroup(group, makeUser({ role: Role.Admin }));
+    // After the assert, TypeScript treats `group` as non-null — compiler
+    // check via property access below; runtime just confirms no throw.
+    expect(group.organizationId).toBe(1);
+  });
+});

--- a/apps/drec-api/src/utils/group-access.ts
+++ b/apps/drec-api/src/utils/group-access.ts
@@ -1,0 +1,80 @@
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { Role } from './enums';
+import { ILoggedInUser } from '../models/LoggedInUser';
+
+/**
+ * Role-aware access check for `device_group` reads (certificate-log, device
+ * audit endpoints, etc.).
+ *
+ * The hard bug this replaces: the old endpoints compared
+ * `group.organizationId != user.organizationId` across the board, which is
+ * only right when the caller happens to be in the group's owning org.
+ * Buyers, Admins, and cross-org integrations all got a generic
+ * `"Group UId is not of this buyer, invalid value was sent"` — confusingly
+ * worded (the check has nothing to do with the buyer role) and with no
+ * way to distinguish why.
+ *
+ * The check a caller passes depends on their role:
+ *
+ *   - `Admin`         → no org restriction. Platform admins see everything.
+ *   - `Registrant`    → `group.api_user_id === user.api_user_id`. An
+ *                       api-key-level scope match; organizationId on the
+ *                       registrant's user row can differ from the group's
+ *                       owning org.
+ *   - `Buyer` / `SubBuyer` → `group.buyerId === user.organizationId`. The
+ *                       buyer's org is the buyer-side of the reservation.
+ *   - Everyone else   → `group.organizationId === user.organizationId`.
+ *                       Legacy same-org check.
+ *
+ * Throws `404 ConflictException` if the group is absent (caller looked up
+ * a non-existent UID), or `403 ForbiddenException` with a role-specific
+ * message if the group exists but the user can't access it.
+ */
+export function assertUserCanAccessGroup(
+  group: GroupForAccessCheck | null,
+  user: ILoggedInUser,
+): asserts group is GroupForAccessCheck {
+  if (group === null) {
+    throw new ConflictException({
+      success: false,
+      message: 'Group UID not found',
+    });
+  }
+
+  switch (user.role) {
+    case Role.Admin:
+      return;
+
+    case Role.Registrant:
+      if (group.api_user_id === user.api_user_id) return;
+      throw new ForbiddenException({
+        success: false,
+        message: 'Group UID does not belong to this registrant',
+      });
+
+    case Role.Buyer:
+    case Role.SubBuyer:
+      if (group.buyerId === user.organizationId) return;
+      throw new ForbiddenException({
+        success: false,
+        message: 'Group UID is not of this buyer',
+      });
+
+    default:
+      if (group.organizationId === user.organizationId) return;
+      throw new ForbiddenException({
+        success: false,
+        message: 'Group UID is not of your organization',
+      });
+  }
+}
+
+/**
+ * Minimal subset of `DeviceGroup` that the access check depends on.
+ * Avoids pulling the whole entity into callers that only need this helper.
+ */
+export interface GroupForAccessCheck {
+  organizationId: number;
+  buyerId: number | null | undefined;
+  api_user_id: string | null | undefined;
+}

--- a/apps/drec-api/src/utils/group-access.ts
+++ b/apps/drec-api/src/utils/group-access.ts
@@ -1,4 +1,4 @@
-import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Role } from './enums';
 import { ILoggedInUser } from '../models/LoggedInUser';
 
@@ -21,21 +21,23 @@ import { ILoggedInUser } from '../models/LoggedInUser';
  *                       api-key-level scope match; organizationId on the
  *                       registrant's user row can differ from the group's
  *                       owning org.
- *   - `Buyer` / `SubBuyer` → `group.buyerId === user.organizationId`. The
- *                       buyer's org is the buyer-side of the reservation.
+ *   - `Buyer` / `SubBuyer` → `group.buyerId === user.organizationId`, OR
+ *                       `group.organizationId === user.organizationId` as a
+ *                       fallback (the buyer's own org directly owns the
+ *                       group, not via the buyer-reservation column).
  *   - Everyone else   → `group.organizationId === user.organizationId`.
  *                       Legacy same-org check.
  *
- * Throws `404 ConflictException` if the group is absent (caller looked up
- * a non-existent UID), or `403 ForbiddenException` with a role-specific
- * message if the group exists but the user can't access it.
+ * Throws `NotFoundException` (404) if the group is absent, or
+ * `ForbiddenException` (403) with a role-specific message if the group
+ * exists but the user can't access it.
  */
 export function assertUserCanAccessGroup(
   group: GroupForAccessCheck | null,
   user: ILoggedInUser,
 ): asserts group is GroupForAccessCheck {
   if (group === null) {
-    throw new ConflictException({
+    throw new NotFoundException({
       success: false,
       message: 'Group UID not found',
     });
@@ -54,7 +56,12 @@ export function assertUserCanAccessGroup(
 
     case Role.Buyer:
     case Role.SubBuyer:
-      if (group.buyerId === user.organizationId) return;
+      if (
+        group.buyerId === user.organizationId ||
+        group.organizationId === user.organizationId
+      ) {
+        return;
+      }
       throw new ForbiddenException({
         success: false,
         message: 'Group UID is not of this buyer',


### PR DESCRIPTION
## Bug

Three endpoints that read by \`groupUid\` compared \`deviceGroup.organizationId != user.organizationId\` and threw \`ConflictException("Group UId is not of this buyer, invalid value was sent")\` on mismatch:

- \`GET /certificate-log/issuer/certified/:groupUid\` (\`certificate-log.controller.ts:197\`)
- \`GET /certificate-log/issuer/certified/new/:groupUid\` (\`certificate-log.controller.ts:270\`)
- \`GET /device/certifiedLogDateRange\` (\`device.controller.ts:1349\`)

Three things wrong:

1. **Misleading error.** The message says "buyer" but the check has nothing to do with the buyer role. A Site Operator, Reviewer, Admin, or any cross-org caller hitting a legitimate group got the same "buyer" error.
2. **Admins were locked out.** The check had no role bypass. PowerTrust's dedicated env uses \`admin@powertrust.local\` as the integration identity (Admins are supposed to have platform-wide read), and the check rejected every call because \`group.organizationId != 1\`. Direct cause of the incident Lekshmi reported today.
3. **Buyers in standard cross-org reservations were rejected.** The usual wiring puts \`group.organizationId\` on the registrant side and \`group.buyerId\` on the buyer's org. When the buyer called, \`buyerId\` matched but \`organizationId\` didn't, so the check threw.

## Fix

New helper \`src/utils/group-access.ts :: assertUserCanAccessGroup(group, user)\` with a single rule per role:

| Role | Allowed when |
|---|---|
| \`Admin\` | always (bypass) |
| \`Registrant\` | \`group.api_user_id === user.api_user_id\` |
| \`Buyer\` / \`SubBuyer\` | \`group.buyerId === user.organizationId\` |
| other | \`group.organizationId === user.organizationId\` |

- Each non-match throws \`ForbiddenException\` with a **role-specific** message ("not this registrant" / "not this buyer" / "not your organization").
- Null group throws \`ConflictException("Group UID not found")\` — kept distinct from "exists but unreadable" so callers can differentiate.
- TypeScript \`asserts group is GroupForAccessCheck\` — the three call sites no longer need explicit null-checks after the helper.
- The three original inline checks are replaced with a single call each; \`Role\`/\`ConflictException\`/\`BadRequestException\` imports dropped where no longer referenced.

## Tests

\`group-access.spec.ts\`: 10 tests covering the happy + reject path for every role + the null-group case. Type-narrowing verified via post-call property access.

## Operational impact on the PowerTrust dedicated env

Previously we worked around this by flipping \`device_group.organizationId\` between the Admin org (1), the Dev/registrant org (3), and the Buyer org (4) depending on which user we knew was calling. Once this PR lands, that dance stops: \`organizationId\` can sit on the registrant side (the conventional wiring) and the Admin, Buyer, and registrant all read the same group without the group needing to be moved around. A follow-up SQL migration can restore the group's org to its conventional position after deploy.

## Not in scope

- Write/mutation endpoints (create/update/delete group) use different checks — untouched.
- Deeper permissions like "which certs within a group can this user see" — untouched.