### PR TITLE
migrations: unblock develop → stage promotion (sequences + Registrant + migrate:docker)

### DIFF
--- a/apps/drec-api/datasource.ts
+++ b/apps/drec-api/datasource.ts
@@ -1,0 +1,25 @@
+import Dotenv from 'dotenv';
+Dotenv.config({ path: '../../.env' });
+
+import { DataSource, DataSourceOptions } from 'typeorm';
+
+const getDBConnectionOptions = (): DataSourceOptions => ({
+  type: 'postgres',
+  host: process.env.DB_HOST ?? 'localhost',
+  port: Number(process.env.DB_PORT) || 5432,
+  username: process.env.DB_USERNAME ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? 'postgres',
+  database: process.env.DB_DATABASE ?? 'origin',
+});
+
+// Invoked by `migrate:docker` via ts-node + typeorm-cli `-d datasource.ts`.
+// typeorm 0.3.x requires a DataSource instance, not a DataSourceOptions object —
+// ormconfig.ts (which exports options) is a carryover from 0.2.x and cannot be
+// used with the 0.3 CLI.
+export default new DataSource({
+  ...getDBConnectionOptions(),
+  synchronize: false,
+  migrationsRun: false,
+  migrations: ['migrations/*.ts'],
+  migrationsTableName: 'migrations_drec',
+});

--- a/apps/drec-api/migrations/1756999999999-AlignSequences.ts
+++ b/apps/drec-api/migrations/1756999999999-AlignSequences.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// Realigns every serial-style sequence on the public schema so last_value
+// matches max(owning_column). Stage's RDS had several sequences — notably
+// user_role_id_seq (last=1, max=6) — out of sync, which broke the next
+// INSERT that used nextval(). Timestamp is deliberately below 1757000000014
+// so this runs before any pending seed/insert migrations on a stale env.
+// Idempotent: on an already-aligned DB, setval() is a no-op.
+export class AlignSequences1756999999999 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      DECLARE r record;
+        maxid bigint;
+      BEGIN
+        FOR r IN
+          SELECT s.sequencename, tbl.relname AS tbl, att.attname AS col
+          FROM pg_sequences s
+            JOIN pg_class c ON c.relname = s.sequencename AND c.relkind = 'S'
+            LEFT JOIN pg_depend d ON d.objid = c.oid AND d.deptype = 'a'
+            LEFT JOIN pg_class tbl ON tbl.oid = d.refobjid
+            LEFT JOIN pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = d.refobjsubid
+          WHERE s.schemaname = 'public' AND tbl.relname IS NOT NULL
+        LOOP
+          EXECUTE format('SELECT coalesce(max(%I),0) FROM %I', r.col, r.tbl) INTO maxid;
+          IF maxid > 0 THEN
+            EXECUTE format('SELECT setval(%L, %s, true)', 'public.'||r.sequencename, maxid);
+          END IF;
+        END LOOP;
+      END $$;
+    `);
+  }
+
+  public async down(): Promise<void> {
+    // no-op: realignment is always safe and cannot be meaningfully reversed
+  }
+}

--- a/apps/drec-api/migrations/1762000000000-EnsureRegistrantRole.ts
+++ b/apps/drec-api/migrations/1762000000000-EnsureRegistrantRole.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// 1759900500000-RenameMarketIntermediaryToRegistrant assumes a
+// MarketIntermediary user_role row exists and renames it to Registrant.
+// On envs that never had MarketIntermediary (e.g. stage, whose role
+// history skipped the MI era), the rename is a no-op yet the same
+// migration deletes OrganizationAdmin anyway — leaving the env with
+// no Registrant role at all. Backfill one here, idempotently.
+export class EnsureRegistrantRole1762000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO "user_role" ("name", "description", "status")
+      SELECT 'Registrant',
+             'Registrant role for device registration and meter read submission',
+             true
+      WHERE NOT EXISTS (SELECT 1 FROM "user_role" WHERE "name" = 'Registrant')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "user_role" WHERE "name" = 'Registrant'`,
+    );
+  }
+}

--- a/apps/drec-api/package.json
+++ b/apps/drec-api/package.json
@@ -26,7 +26,7 @@
     "lint:fix": "eslint \"**/*{.ts,.tsx}\" --fix",
     "migrate": "pnpm typeorm:run:issuer && pnpm typeorm:run && pnpm typeorm:run:certificate",
     "migration:create": "typeorm migration:create -d ./migrations",
-    "migrate:docker": "pnpm typeorm:run:issuer && node_modules/typeorm/cli.js --config dist/js/ormconfig.js migration:run",
+    "migrate:docker": "pnpm typeorm:run:issuer && ts-node -r tsconfig-paths/register node_modules/typeorm/cli.js migration:run -d datasource.ts",
     "typeorm": "ts-node -r tsconfig-paths/register node_modules/typeorm/cli.js -d ormconfig-dev.ts",
     "typeorm:migrate": "pnpm typeorm migration:generate -- -n",
     "typeorm:run": "pnpm typeorm migration:run || { echo \"Migration failed\"; exit 1; } && echo \"Migration Successfull\"",


### PR DESCRIPTION
## Summary
Three findings from dry-running develop's 42 pending migrations against a schema+data snapshot of stage's RDS. Yesterday's failed promotion (#764/#765 reverted in #766) hit all of these; this PR fixes them so the next promotion attempt goes clean.

### 1. AlignSequences migration (timestamp 1756999999999)
Stage's `user_role_id_seq.last_value = 1` but `user_role.max(id) = 6`. `AddReviewerRoles1757000000015` used `DEFAULT nextval()` and hit `duplicate key value violates unique constraint "user_role_pkey"`. Four sequences drifted in total (`user_role_id_seq`, `aclmodules_id_seq`, `old_issuer_log_id_seq`, `issuer_certificate_id_seq`). New migration realigns every sequence on the `public` schema to `max(owning_col)` via pg_depend walk. Timestamp is deliberately < 1757000000014 so it runs before any pending insert/seed on a stale env. Idempotent: setval on an already-correct sequence is a no-op.

### 2. EnsureRegistrantRole migration (timestamp 1762000000000)
`1759900500000-RenameMarketIntermediaryToRegistrant` renames a `MarketIntermediary` user_role row to `Registrant`. Stage never had `MarketIntermediary` (role history skipped that era), so the rename is a no-op — yet the same migration still deletes `OrganizationAdmin`, leaving the env with no `Registrant` at all. New follow-up migration does `INSERT … WHERE NOT EXISTS` so any env lands with a Registrant row.

### 3. Fix broken `migrate:docker` script
Old script: `pnpm typeorm:run:issuer && node_modules/typeorm/cli.js --config dist/js/ormconfig.js migration:run`. The `--config` flag is typeorm 0.2.x; the 0.3.x CLI rejects it with "Missing required argument: dataSource". PR #767's Job would have failed regardless of DB state. New `datasource.ts` exports a `DataSource` instance (matching the `datasource-issuer.ts` / `datasource-certificate.ts` pattern); script now uses `ts-node -r tsconfig-paths/register … migration:run -d datasource.ts`.

## Test plan
- [x] pg_dump schema+data of stage → local throwaway Postgres on :15432
- [x] Run `pnpm migrate:docker` against that snapshot → all 44 migrations complete cleanly
- [x] Verify final state: `user_role` includes `Registrant` (id=9), `user_role_id_seq` aligned (=9), `aclmodules_id_seq` aligned (=15), `device.evidence_pathway` column present
- [ ] After merge, let #767's stage migration Job run against real stage RDS
- [ ] Confirm stage comes up healthy with new schema

## Out of scope / follow-ups
- `ormconfig.ts` is now unused by our own code (only vendor `@energyweb/*/ormconfig` is referenced). Could be deleted in a cleanup PR.
- `Dockerfile.migrations` and `drec-api-migrate-dev.yaml` in drec-infrastructure are still dead scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)