### PR TITLE
fix: backport 3 stage-deploy fixes to develop

### DIFF
--- a/.github/workflows/deploy-ecr-k8s.yaml
+++ b/.github/workflows/deploy-ecr-k8s.yaml
@@ -63,6 +63,12 @@ jobs:
                   - name: migrate
                     image: ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
                     command: ["npm", "run", "migrate:docker"]
+                    env:
+                      # ts-node otherwise type-checks datasource*.ts and needs
+                      # @types/node + @types/mocha, which pnpm prune --prod
+                      # strips. Migrations were type-checked at build time.
+                      - name: TS_NODE_TRANSPILE_ONLY
+                        value: "true"
                     envFrom:
                       - secretRef:
                           name: drec-${K8S_NAMESPACE}-env

--- a/apps/drec-api/migrations/1756999999999-AlignSequences.ts
+++ b/apps/drec-api/migrations/1756999999999-AlignSequences.ts
@@ -24,7 +24,10 @@ export class AlignSequences1756999999999 implements MigrationInterface {
         LOOP
           EXECUTE format('SELECT coalesce(max(%I),0) FROM %I', r.col, r.tbl) INTO maxid;
           IF maxid > 0 THEN
-            EXECUTE format('SELECT setval(%L, %s, true)', 'public.'||r.sequencename, maxid);
+            -- quote_ident preserves mixed-case sequence names (e.g.
+            -- device_csv_file_processing_jobs_jobId_seq); pass as the
+            -- unqualified identifier — resolves via public on the search_path.
+            EXECUTE format('SELECT setval(%L, %s, true)', quote_ident(r.sequencename), maxid);
           END IF;
         END LOOP;
       END $$;

--- a/apps/drec-api/package.json
+++ b/apps/drec-api/package.json
@@ -143,6 +143,7 @@
     "stream": "^0.0.2",
     "swagger-ui-express": "4.1.6",
     "terser": "^5.14.2",
+    "ts-node": "9.1.0",
     "tsconfig-paths": "^4.2.0",
     "typeorm": "0.3.28",
     "typescript": "5.1.3",
@@ -190,8 +191,7 @@
     "sinon": "^17.0.1",
     "standard-version": "^9.5.0",
     "supertest": "6.0.1",
-    "ts-jest": "29.2.3",
-    "ts-node": "9.1.0"
+    "ts-jest": "29.2.3"
   },
   "standard-version": {
     "scripts": {


### PR DESCRIPTION
## Summary
Backports 3 fixes discovered during today's develop→stage promotion so they don't need to be rediscovered next time.

1. **move ts-node to dependencies** — was in devDependencies and got stripped by \`pnpm prune --prod\`. Migration Job failed with \`sh: ts-node: not found\`.
2. **TS_NODE_TRANSPILE_ONLY=true in migration Job spec** — ts-node type-checks datasource-issuer.ts / datasource.ts before executing; this needs @types/node + @types/mocha which are also pruned. Migrations are already type-checked at build time.
3. **AlignSequences — quote_ident for mixed-case sequence names** — unquoted \`'public.'||r.sequencename\` gets lowercased by the parser. \`device_csv_file_processing_jobs_jobId_seq\` → \`..._jobid_seq\` → "relation does not exist". The dry-run missed this because the owning table was empty in my narrow local data subset.

One fix on stage (the TS duplicate-function / SCREENSHOTS cleanup) was merge-artifact-only and doesn't apply to develop directly, so it's not backported.

## Context

Develop→stage promotion (#769) shipped today. Migrations ran successfully on real stage RDS (all 44 pending migrations applied). Rollout is blocked by an unrelated EKS node-health incident — Karpenter-provisioned nodes and nodegroup nodes both failing to register with the control plane. That's an infra issue, not a code issue.

## Test plan
- [x] All three fixes verified live on stage
- [ ] Next develop→stage promotion uses these without re-discovering them

🤖 Generated with [Claude Code](https://claude.com/claude-code)