### PR TITLE
chore(lint): fix 11 ESLint errors + 55 Prettier drift

### DIFF
--- a/apps/drec-api/datasource-certificate.ts
+++ b/apps/drec-api/datasource-certificate.ts
@@ -22,9 +22,7 @@ const migrationClasses = fs
   .filter((f) => f.endsWith('.js') && !f.endsWith('.d.js'))
   .flatMap((f) => {
     const exports = require(path.join(migrationsDir, f));
-    return Object.values(exports).filter(
-      (v) => typeof v === 'function',
-    );
+    return Object.values(exports).filter((v) => typeof v === 'function');
   });
 
 export default new DataSource({ ...config, migrations: migrationClasses });

--- a/apps/drec-api/datasource-issuer.ts
+++ b/apps/drec-api/datasource-issuer.ts
@@ -20,9 +20,7 @@ const migrationClasses = fs
   .filter((f) => f.endsWith('.js') && !f.endsWith('.d.js'))
   .flatMap((f) => {
     const exports = require(path.join(migrationsDir, f));
-    return Object.values(exports).filter(
-      (v) => typeof v === 'function',
-    );
+    return Object.values(exports).filter((v) => typeof v === 'function');
   });
 
 export default new DataSource({ ...config, migrations: migrationClasses });

--- a/apps/drec-api/migrations/1743609600000-RenameApiUserToMarketIntermediary.ts
+++ b/apps/drec-api/migrations/1743609600000-RenameApiUserToMarketIntermediary.ts
@@ -1,16 +1,30 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class RenameApiUserToMarketIntermediary1743609600000 implements MigrationInterface {
+export class RenameApiUserToMarketIntermediary1743609600000
+  implements MigrationInterface
+{
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Update role values
-    await queryRunner.query(`UPDATE "user" SET role = 'MarketIntermediary' WHERE role = 'ApiUser'`);
-    await queryRunner.query(`UPDATE user_role SET name = 'MarketIntermediary' WHERE name = 'ApiUser'`);
-    await queryRunner.query(`UPDATE organization SET "organizationType" = 'MarketIntermediary' WHERE "organizationType" = 'ApiUser'`);
+    await queryRunner.query(
+      `UPDATE "user" SET role = 'MarketIntermediary' WHERE role = 'ApiUser'`,
+    );
+    await queryRunner.query(
+      `UPDATE user_role SET name = 'MarketIntermediary' WHERE name = 'ApiUser'`,
+    );
+    await queryRunner.query(
+      `UPDATE organization SET "organizationType" = 'MarketIntermediary' WHERE "organizationType" = 'ApiUser'`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`UPDATE "user" SET role = 'ApiUser' WHERE role = 'MarketIntermediary'`);
-    await queryRunner.query(`UPDATE user_role SET name = 'ApiUser' WHERE name = 'MarketIntermediary'`);
-    await queryRunner.query(`UPDATE organization SET "organizationType" = 'ApiUser' WHERE "organizationType" = 'MarketIntermediary'`);
+    await queryRunner.query(
+      `UPDATE "user" SET role = 'ApiUser' WHERE role = 'MarketIntermediary'`,
+    );
+    await queryRunner.query(
+      `UPDATE user_role SET name = 'ApiUser' WHERE name = 'MarketIntermediary'`,
+    );
+    await queryRunner.query(
+      `UPDATE organization SET "organizationType" = 'ApiUser' WHERE "organizationType" = 'MarketIntermediary'`,
+    );
   }
 }

--- a/apps/drec-api/migrations/1757000000021-AddGroupReviewStatusToDeviceGroup.ts
+++ b/apps/drec-api/migrations/1757000000021-AddGroupReviewStatusToDeviceGroup.ts
@@ -22,8 +22,6 @@ export class AddGroupReviewStatusToDeviceGroup1757000000021
     await queryRunner.query(
       `ALTER TABLE "device_group" DROP COLUMN IF EXISTS "group_review_status"`,
     );
-    await queryRunner.query(
-      `DROP TYPE IF EXISTS "group_review_status_enum"`,
-    );
+    await queryRunner.query(`DROP TYPE IF EXISTS "group_review_status_enum"`);
   }
 }

--- a/apps/drec-api/migrations/1759900300000-SeedMissingRolePermissions.ts
+++ b/apps/drec-api/migrations/1759900300000-SeedMissingRolePermissions.ts
@@ -51,14 +51,42 @@ export class SeedMissingRolePermissions1759900300000
     // --- 4. Fix DeviceOwner: grant same permissions as OrgAdmin ---
     const modules = [
       { name: 'USER_MANAGEMENT_CRUDL', perms: 'Read,Write,Update', value: 7 },
-      { name: 'ORGANIZATION_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
-      { name: 'FILE_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
-      { name: 'DEVICE_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
-      { name: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
-      { name: 'DEVICE_BULK_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
-      { name: 'READS_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
+      {
+        name: 'ORGANIZATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        name: 'FILE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        name: 'DEVICE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        name: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        name: 'DEVICE_BULK_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        name: 'READS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
       { name: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
-      { name: 'INVITATION_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
+      {
+        name: 'INVITATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
       { name: 'PASSWORD_MANAGEMENT_CRUDL', perms: 'Write', value: 2 },
     ];
 
@@ -104,6 +132,8 @@ export class SeedMissingRolePermissions1759900300000
         AND "entityId" = (SELECT id FROM "user_role" WHERE name = 'MarketIntermediary')
         AND "aclmodulesId" IN (SELECT id FROM "aclmodules" WHERE name IN ('ORGANIZATION_MANAGEMENT_CRUDL', 'USER_MANAGEMENT_CRUDL'))
     `);
-    await queryRunner.query(`DELETE FROM "user_role" WHERE "name" = 'SiteOperator'`);
+    await queryRunner.query(
+      `DELETE FROM "user_role" WHERE "name" = 'SiteOperator'`,
+    );
   }
 }

--- a/apps/drec-api/migrations/1759900400000-MigrateDeveloperToMarketIntermediary.ts
+++ b/apps/drec-api/migrations/1759900400000-MigrateDeveloperToMarketIntermediary.ts
@@ -22,7 +22,7 @@ export class MigrateDeveloperToMarketIntermediary1759900400000
     `);
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
+  public async down(): Promise<void> {
     // Cannot reliably reverse — we don't know which orgs were originally Developer
     // This is intentionally a no-op
   }

--- a/apps/drec-api/migrations/1759900600000-MergeDeviceOwnerIntoSiteOperator.ts
+++ b/apps/drec-api/migrations/1759900600000-MergeDeviceOwnerIntoSiteOperator.ts
@@ -28,7 +28,8 @@ export class MergeDeviceOwnerIntoSiteOperator1759900600000
     } else {
       // SiteOperator row exists — merge permissions and delete DeviceOwner row
       const siteOpId = siteOpRole[0].id;
-      await queryRunner.query(`
+      await queryRunner.query(
+        `
         UPDATE "aclmodulepermissions"
         SET "entityId" = $1
         WHERE "entityId" = 3
@@ -37,7 +38,9 @@ export class MergeDeviceOwnerIntoSiteOperator1759900600000
             SELECT "aclmodulesId" FROM "aclmodulepermissions"
             WHERE "entityId" = $1 AND "entityType" = 'Role'
           )
-      `, [siteOpId]);
+      `,
+        [siteOpId],
+      );
 
       await queryRunner.query(`
         DELETE FROM "aclmodulepermissions"

--- a/apps/drec-api/migrations/1759900700000-FixStaleRoleIds.ts
+++ b/apps/drec-api/migrations/1759900700000-FixStaleRoleIds.ts
@@ -13,7 +13,7 @@ export class FixStaleRoleIds1759900700000 implements MigrationInterface {
     `);
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
+  public async down(): Promise<void> {
     // No revert needed — this is a data consistency fix
   }
 }

--- a/apps/drec-api/migrations/1759901000000-BackfillCoreAclModules.ts
+++ b/apps/drec-api/migrations/1759901000000-BackfillCoreAclModules.ts
@@ -10,23 +10,93 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * non-Admin user then hits a 500 because PermissionGuard cannot resolve
  * the module id.
  */
-export class BackfillCoreAclModules1759901000000
-  implements MigrationInterface
-{
+export class BackfillCoreAclModules1759901000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     const modules = [
-      { id: 1,  name: 'USER_MANAGEMENT_CRUDL',             desc: 'User module management',                perms: 'Read,Write,Update,Delete', val: 15 },
-      { id: 2,  name: 'ORGANIZATION_MANAGEMENT_CRUDL',     desc: 'Organization module management',        perms: 'Read,Write,Update,Delete', val: 15 },
-      { id: 3,  name: 'FILE_MANAGEMENT_CRUDL',             desc: 'File module management',                perms: 'Read,Write,Update,Delete', val: 15 },
-      { id: 4,  name: 'DEVICE_MANAGEMENT_CRUDL',           desc: 'Device module management',              perms: 'Read,Write,Update,Delete', val: 15 },
-      { id: 5,  name: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',  desc: 'Buyer Reservation module management',   perms: 'Read,Write,Update,Delete', val: 15 },
-      { id: 6,  name: 'DEVICE_BULK_MANAGEMENT_CRUDL',      desc: 'Bulk Device management',                perms: 'Read,Write,Update,Delete', val: 15 },
-      { id: 7,  name: 'READS_MANAGEMENT_CRUDL',            desc: 'Reads module management',               perms: 'Read,Write,Update,Delete', val: 15 },
-      { id: 8,  name: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL',  desc: 'Certificate Log module management',     perms: 'Read',                     val: 1  },
-      { id: 9,  name: 'INVITATION_MANAGEMENT_CRUDL',       desc: 'Invitation module management',          perms: 'Read,Write,Update,Delete', val: 15 },
-      { id: 10, name: 'ADMIN_APIUSER_ORGANIZATION_CRUDL',  desc: 'Organization information management',   perms: 'Read,Write,Update,Delete', val: 15 },
-      { id: 11, name: 'PASSWORD_MANAGEMENT_CRUDL',         desc: 'Password management',                   perms: 'Write',                    val: 2  },
-      { id: 12, name: 'PERMISSION_MANAGEMENT_CRUDL',       desc: 'Permission module management',          perms: 'Read,Write,Update',        val: 7  },
+      {
+        id: 1,
+        name: 'USER_MANAGEMENT_CRUDL',
+        desc: 'User module management',
+        perms: 'Read,Write,Update,Delete',
+        val: 15,
+      },
+      {
+        id: 2,
+        name: 'ORGANIZATION_MANAGEMENT_CRUDL',
+        desc: 'Organization module management',
+        perms: 'Read,Write,Update,Delete',
+        val: 15,
+      },
+      {
+        id: 3,
+        name: 'FILE_MANAGEMENT_CRUDL',
+        desc: 'File module management',
+        perms: 'Read,Write,Update,Delete',
+        val: 15,
+      },
+      {
+        id: 4,
+        name: 'DEVICE_MANAGEMENT_CRUDL',
+        desc: 'Device module management',
+        perms: 'Read,Write,Update,Delete',
+        val: 15,
+      },
+      {
+        id: 5,
+        name: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',
+        desc: 'Buyer Reservation module management',
+        perms: 'Read,Write,Update,Delete',
+        val: 15,
+      },
+      {
+        id: 6,
+        name: 'DEVICE_BULK_MANAGEMENT_CRUDL',
+        desc: 'Bulk Device management',
+        perms: 'Read,Write,Update,Delete',
+        val: 15,
+      },
+      {
+        id: 7,
+        name: 'READS_MANAGEMENT_CRUDL',
+        desc: 'Reads module management',
+        perms: 'Read,Write,Update,Delete',
+        val: 15,
+      },
+      {
+        id: 8,
+        name: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL',
+        desc: 'Certificate Log module management',
+        perms: 'Read',
+        val: 1,
+      },
+      {
+        id: 9,
+        name: 'INVITATION_MANAGEMENT_CRUDL',
+        desc: 'Invitation module management',
+        perms: 'Read,Write,Update,Delete',
+        val: 15,
+      },
+      {
+        id: 10,
+        name: 'ADMIN_APIUSER_ORGANIZATION_CRUDL',
+        desc: 'Organization information management',
+        perms: 'Read,Write,Update,Delete',
+        val: 15,
+      },
+      {
+        id: 11,
+        name: 'PASSWORD_MANAGEMENT_CRUDL',
+        desc: 'Password management',
+        perms: 'Write',
+        val: 2,
+      },
+      {
+        id: 12,
+        name: 'PERMISSION_MANAGEMENT_CRUDL',
+        desc: 'Permission module management',
+        perms: 'Read,Write,Update',
+        val: 7,
+      },
     ];
 
     for (const m of modules) {

--- a/apps/drec-api/migrations/1759901100000-SeedCoreRolePermissions.ts
+++ b/apps/drec-api/migrations/1759901100000-SeedCoreRolePermissions.ts
@@ -24,43 +24,188 @@ export class SeedCoreRolePermissions1759901100000
       value: number;
     }[] = [
       // ── Registrant ──
-      { role: 'Registrant', module: 'USER_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'Registrant', module: 'ORGANIZATION_MANAGEMENT_CRUDL',    perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'Registrant', module: 'FILE_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'Registrant', module: 'DEVICE_MANAGEMENT_CRUDL',          perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'Registrant', module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'Registrant', module: 'DEVICE_BULK_MANAGEMENT_CRUDL',     perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'Registrant', module: 'READS_MANAGEMENT_CRUDL',           perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'Registrant', module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read',                     value: 1  },
-      { role: 'Registrant', module: 'INVITATION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'Registrant', module: 'PASSWORD_MANAGEMENT_CRUDL',        perms: 'Write',                    value: 2  },
-      { role: 'Registrant', module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',  perms: 'Read,Write',               value: 3  },
-      { role: 'Registrant', module: 'SUBMISSION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
+      {
+        role: 'Registrant',
+        module: 'USER_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'Registrant',
+        module: 'ORGANIZATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'Registrant',
+        module: 'FILE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'Registrant',
+        module: 'DEVICE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'Registrant',
+        module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'Registrant',
+        module: 'DEVICE_BULK_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'Registrant',
+        module: 'READS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'Registrant',
+        module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL',
+        perms: 'Read',
+        value: 1,
+      },
+      {
+        role: 'Registrant',
+        module: 'INVITATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'Registrant',
+        module: 'PASSWORD_MANAGEMENT_CRUDL',
+        perms: 'Write',
+        value: 2,
+      },
+      {
+        role: 'Registrant',
+        module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write',
+        value: 3,
+      },
+      {
+        role: 'Registrant',
+        module: 'SUBMISSION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
 
       // ── Buyer ──
-      { role: 'Buyer', module: 'USER_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update', value: 7  },
-      { role: 'Buyer', module: 'ORGANIZATION_MANAGEMENT_CRUDL',    perms: 'Read',              value: 1  },
-      { role: 'Buyer', module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read',              value: 1  },
-      { role: 'Buyer', module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read',              value: 1  },
-      { role: 'Buyer', module: 'INVITATION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'Buyer', module: 'PASSWORD_MANAGEMENT_CRUDL',        perms: 'Write',             value: 2  },
+      {
+        role: 'Buyer',
+        module: 'USER_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update',
+        value: 7,
+      },
+      {
+        role: 'Buyer',
+        module: 'ORGANIZATION_MANAGEMENT_CRUDL',
+        perms: 'Read',
+        value: 1,
+      },
+      {
+        role: 'Buyer',
+        module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',
+        perms: 'Read',
+        value: 1,
+      },
+      {
+        role: 'Buyer',
+        module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL',
+        perms: 'Read',
+        value: 1,
+      },
+      {
+        role: 'Buyer',
+        module: 'INVITATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'Buyer',
+        module: 'PASSWORD_MANAGEMENT_CRUDL',
+        perms: 'Write',
+        value: 2,
+      },
 
       // ── SubBuyer ──
-      { role: 'SubBuyer', module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read,Write',               value: 3  },
-      { role: 'SubBuyer', module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read',                     value: 1  },
-      { role: 'SubBuyer', module: 'INVITATION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'SubBuyer', module: 'PASSWORD_MANAGEMENT_CRUDL',        perms: 'Write',                    value: 2  },
+      {
+        role: 'SubBuyer',
+        module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',
+        perms: 'Read,Write',
+        value: 3,
+      },
+      {
+        role: 'SubBuyer',
+        module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL',
+        perms: 'Read',
+        value: 1,
+      },
+      {
+        role: 'SubBuyer',
+        module: 'INVITATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'SubBuyer',
+        module: 'PASSWORD_MANAGEMENT_CRUDL',
+        perms: 'Write',
+        value: 2,
+      },
 
       // ── MarketIntermediary (modules not covered by 1759900300000) ──
-      { role: 'MarketIntermediary', module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read',                     value: 1  },
-      { role: 'MarketIntermediary', module: 'DEVICE_MANAGEMENT_CRUDL',          perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'MarketIntermediary', module: 'FILE_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'MarketIntermediary', module: 'READS_MANAGEMENT_CRUDL',           perms: 'Read,Write,Update,Delete', value: 15 },
-      { role: 'MarketIntermediary', module: 'PASSWORD_MANAGEMENT_CRUDL',        perms: 'Write',                    value: 2  },
+      {
+        role: 'MarketIntermediary',
+        module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL',
+        perms: 'Read',
+        value: 1,
+      },
+      {
+        role: 'MarketIntermediary',
+        module: 'DEVICE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'MarketIntermediary',
+        module: 'FILE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'MarketIntermediary',
+        module: 'READS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        role: 'MarketIntermediary',
+        module: 'PASSWORD_MANAGEMENT_CRUDL',
+        perms: 'Write',
+        value: 2,
+      },
 
       // ── Reviewer / SeniorReviewer: DEVICE_MANAGEMENT Read (not covered by 1759800000000) ──
-      { role: 'Reviewer',       module: 'DEVICE_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
-      { role: 'SeniorReviewer', module: 'DEVICE_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      {
+        role: 'Reviewer',
+        module: 'DEVICE_MANAGEMENT_CRUDL',
+        perms: 'Read',
+        value: 1,
+      },
+      {
+        role: 'SeniorReviewer',
+        module: 'DEVICE_MANAGEMENT_CRUDL',
+        perms: 'Read',
+        value: 1,
+      },
     ];
 
     for (const p of permissions) {
@@ -81,11 +226,7 @@ export class SeedCoreRolePermissions1759901100000
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    const roles = [
-      'Registrant',
-      'Buyer',
-      'SubBuyer',
-    ];
+    const roles = ['Registrant', 'Buyer', 'SubBuyer'];
     for (const role of roles) {
       await queryRunner.query(`
         DELETE FROM "aclmodulepermissions"

--- a/apps/drec-api/migrations/1759950000000-AddOwnershipAndSubsidyFieldsToDevice.ts
+++ b/apps/drec-api/migrations/1759950000000-AddOwnershipAndSubsidyFieldsToDevice.ts
@@ -54,9 +54,7 @@ export class AddOwnershipAndSubsidyFieldsToDevice1759950000000
     await queryRunner.query(
       `ALTER TABLE "device" DROP COLUMN "subsidy_types";`,
     );
-    await queryRunner.query(
-      `ALTER TABLE "device" DROP COLUMN "has_subsidy";`,
-    );
+    await queryRunner.query(`ALTER TABLE "device" DROP COLUMN "has_subsidy";`);
     await queryRunner.query(
       `ALTER TABLE "device" DROP COLUMN "off_taker_same_company_as_owner";`,
     );

--- a/apps/drec-api/migrations/1759960000000-AddFacilityTechnicalFieldsToDevice.ts
+++ b/apps/drec-api/migrations/1759960000000-AddFacilityTechnicalFieldsToDevice.ts
@@ -30,8 +30,6 @@ export class AddFacilityTechnicalFieldsToDevice1759960000000
     await queryRunner.query(
       `ALTER TABLE "device" DROP COLUMN "generating_unit_count";`,
     );
-    await queryRunner.query(
-      `ALTER TABLE "device" DROP COLUMN "meter_ids";`,
-    );
+    await queryRunner.query(`ALTER TABLE "device" DROP COLUMN "meter_ids";`);
   }
 }

--- a/apps/drec-api/migrations/1760600000000-AddRoboflowWorkflowUrl.ts
+++ b/apps/drec-api/migrations/1760600000000-AddRoboflowWorkflowUrl.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddRoboflowWorkflowUrl1760600000000
-  implements MigrationInterface
-{
+export class AddRoboflowWorkflowUrl1760600000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE "org_api_licenses"

--- a/apps/drec-api/migrations/1761400000000-DropMeterIdsFromDevice.ts
+++ b/apps/drec-api/migrations/1761400000000-DropMeterIdsFromDevice.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class DropMeterIdsFromDevice1761400000000
-  implements MigrationInterface
-{
+export class DropMeterIdsFromDevice1761400000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       UPDATE device

--- a/apps/drec-api/migrations/1761600000000-MergeScreenshotsIntoMeteringEvidence.ts
+++ b/apps/drec-api/migrations/1761600000000-MergeScreenshotsIntoMeteringEvidence.ts
@@ -15,7 +15,7 @@ export class MergeScreenshotsIntoMeteringEvidence1761600000000
     `);
   }
 
-  public async down(_queryRunner: QueryRunner): Promise<void> {
+  public async down(): Promise<void> {
     // Merge is intentionally one-way — no reliable way to re-split rows by
     // original source once they've been reclassified.
   }

--- a/apps/drec-api/migrations/1762100000000-BackfillRegistrantRolePermissions.ts
+++ b/apps/drec-api/migrations/1762100000000-BackfillRegistrantRolePermissions.ts
@@ -23,18 +23,58 @@ export class BackfillRegistrantRolePermissions1762100000000
       perms: string;
       value: number;
     }[] = [
-      { module: 'USER_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'ORGANIZATION_MANAGEMENT_CRUDL',    perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'FILE_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'DEVICE_MANAGEMENT_CRUDL',          perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'DEVICE_BULK_MANAGEMENT_CRUDL',     perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'READS_MANAGEMENT_CRUDL',           perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read',                     value: 1  },
-      { module: 'INVITATION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'PASSWORD_MANAGEMENT_CRUDL',        perms: 'Write',                    value: 2  },
-      { module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',  perms: 'Read,Write',               value: 3  },
-      { module: 'SUBMISSION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
+      {
+        module: 'USER_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'ORGANIZATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'FILE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'DEVICE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'DEVICE_BULK_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'READS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      {
+        module: 'INVITATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      { module: 'PASSWORD_MANAGEMENT_CRUDL', perms: 'Write', value: 2 },
+      {
+        module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write',
+        value: 3,
+      },
+      {
+        module: 'SUBMISSION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
     ];
 
     for (const p of permissions) {
@@ -54,7 +94,7 @@ export class BackfillRegistrantRolePermissions1762100000000
     }
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
+  public async down(): Promise<void> {
     // No-op: this migration only fills holes left by an earlier
     // migration. Reverting it would delete legitimate permission
     // rows that the original migration was meant to create.

--- a/apps/drec-api/migrations/1762200000000-DedupeUserRoleAndAddPrimaryKey.ts
+++ b/apps/drec-api/migrations/1762200000000-DedupeUserRoleAndAddPrimaryKey.ts
@@ -22,15 +22,36 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 //   6. Add the PK + UNIQUE(name) constraints that should have been there
 //      since 2021.
 //   7. Realign user_role_id_seq.
-const CANONICAL: ReadonlyArray<{ id: number; name: string; description: string }> = [
-  { id: 1, name: 'Admin',          description: 'for admin role' },
-  { id: 3, name: 'SiteOperator',   description: 'Site Operator role for device management' },
-  { id: 4, name: 'Buyer',          description: 'for Buyer role' },
-  { id: 5, name: 'User',           description: 'for User role' },
-  { id: 6, name: 'Registrant',     description: 'Registrant role for device registration and meter read submission' },
-  { id: 7, name: 'SubBuyer',       description: 'Same as buyer but not delete any user of org' },
-  { id: 8, name: 'Reviewer',       description: 'Reviewer role for device reviews' },
-  { id: 9, name: 'SeniorReviewer', description: 'Senior Reviewer role for device reviews' },
+const CANONICAL: ReadonlyArray<{
+  id: number;
+  name: string;
+  description: string;
+}> = [
+  { id: 1, name: 'Admin', description: 'for admin role' },
+  {
+    id: 3,
+    name: 'SiteOperator',
+    description: 'Site Operator role for device management',
+  },
+  { id: 4, name: 'Buyer', description: 'for Buyer role' },
+  { id: 5, name: 'User', description: 'for User role' },
+  {
+    id: 6,
+    name: 'Registrant',
+    description:
+      'Registrant role for device registration and meter read submission',
+  },
+  {
+    id: 7,
+    name: 'SubBuyer',
+    description: 'Same as buyer but not delete any user of org',
+  },
+  { id: 8, name: 'Reviewer', description: 'Reviewer role for device reviews' },
+  {
+    id: 9,
+    name: 'SeniorReviewer',
+    description: 'Senior Reviewer role for device reviews',
+  },
 ];
 
 export class DedupeUserRoleAndAddPrimaryKey1762200000000

--- a/apps/drec-api/migrations/9999999999999-Seed.ts
+++ b/apps/drec-api/migrations/9999999999999-Seed.ts
@@ -10,10 +10,7 @@ import {
 } from '@energyweb/issuer';
 import { getProviderWithFallback } from '@energyweb/utils-general';
 
-import {
-  IRoleConfig,
-  IACLModuleConfig,
-} from '../src/models';
+import { IRoleConfig, IACLModuleConfig } from '../src/models';
 import { v4 as uuid } from 'uuid';
 import bcrypt from 'bcryptjs';
 
@@ -259,7 +256,9 @@ export class Seed9999999999999 implements MigrationInterface {
     const email = process.env.REGISTRANT_EMAIL;
     const pass = process.env.REGISTRANT_PASSWORD;
     if (!email || !pass) {
-      this.logger.verbose('REGISTRANT_EMAIL / REGISTRANT_PASSWORD not set — skipping registrant seed.');
+      this.logger.verbose(
+        'REGISTRANT_EMAIL / REGISTRANT_PASSWORD not set — skipping registrant seed.',
+      );
       return;
     }
 
@@ -281,7 +280,8 @@ export class Seed9999999999999 implements MigrationInterface {
 
     const apiUserId = apiUser[0].api_user_id;
 
-    const organization = await queryRunner.query(`INSERT INTO public.organization (
+    const organization =
+      await queryRunner.query(`INSERT INTO public.organization (
       "name",
       "address",
       "organizationType",
@@ -337,7 +337,9 @@ export class Seed9999999999999 implements MigrationInterface {
     const email = process.env.REVIEWER_EMAIL;
     const pass = process.env.REVIEWER_PASSWORD;
     if (!email || !pass) {
-      this.logger.verbose('REVIEWER_EMAIL / REVIEWER_PASSWORD not set — skipping reviewer seed.');
+      this.logger.verbose(
+        'REVIEWER_EMAIL / REVIEWER_PASSWORD not set — skipping reviewer seed.',
+      );
       return;
     }
 
@@ -404,7 +406,9 @@ export class Seed9999999999999 implements MigrationInterface {
     const email = process.env.BUYER_EMAIL;
     const pass = process.env.BUYER_PASSWORD;
     if (!email || !pass) {
-      this.logger.verbose('BUYER_EMAIL / BUYER_PASSWORD not set — skipping buyer seed.');
+      this.logger.verbose(
+        'BUYER_EMAIL / BUYER_PASSWORD not set — skipping buyer seed.',
+      );
       return;
     }
 
@@ -426,7 +430,8 @@ export class Seed9999999999999 implements MigrationInterface {
 
     const apiUserId = apiUser[0].api_user_id;
 
-    const organization = await queryRunner.query(`INSERT INTO public.organization (
+    const organization =
+      await queryRunner.query(`INSERT INTO public.organization (
       "name",
       "address",
       "organizationType",

--- a/apps/drec-api/src/auth/auth.service.spec.ts
+++ b/apps/drec-api/src/auth/auth.service.spec.ts
@@ -22,7 +22,6 @@ describe('AuthService', () => {
   let userService: UserService;
   let jwtService: JwtService;
 
-
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -61,9 +60,7 @@ describe('AuthService', () => {
     service = module.get<AuthService>(AuthService);
     userService = module.get<UserService>(UserService);
     jwtService = module.get<JwtService>(JwtService);
-    module.get<OauthClientCredentialsService>(
-      OauthClientCredentialsService,
-    );
+    module.get<OauthClientCredentialsService>(OauthClientCredentialsService);
   });
 
   it('should be defined', () => {

--- a/apps/drec-api/src/docs/swagger/index.ts
+++ b/apps/drec-api/src/docs/swagger/index.ts
@@ -14,9 +14,9 @@ export const getDocumentBuilder = (): DocumentBuilder => {
       'access-token',
     );
 
-  [...Tags].sort((a, b) => a.name.localeCompare(b.name)).forEach((tag) =>
-    options.addTag(tag.name, tag.description),
-  );
+  [...Tags]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .forEach((tag) => options.addTag(tag.name, tag.description));
 
   return options;
 };

--- a/apps/drec-api/src/guards/WithoutAuthGuard.ts
+++ b/apps/drec-api/src/guards/WithoutAuthGuard.ts
@@ -81,8 +81,7 @@ export class WithoutAuthGuard implements CanActivate {
 
   private async resolveRegisterUser(request: any): Promise<IUser> {
     const adminUser = await this.userService.findOne({ role: Role.Admin });
-    const isBuyer =
-      request.body.organizationType === OrganizationType.Buyer;
+    const isBuyer = request.body.organizationType === OrganizationType.Buyer;
     const isSiteOperator =
       request.body.organizationType === OrganizationType.SiteOperator;
 
@@ -109,7 +108,8 @@ export class WithoutAuthGuard implements CanActivate {
     }
 
     if (request.body.organizationType === OrganizationType.Registrant) {
-      const registrant = await this.oauthClientCredentialsService.createRegistrant();
+      const registrant =
+        await this.oauthClientCredentialsService.createRegistrant();
       request.body.api_user_id = registrant.api_user_id;
     }
 
@@ -122,8 +122,7 @@ export class WithoutAuthGuard implements CanActivate {
     user: IUser,
   ): Promise<void> {
     const skipRoleCheck =
-      pathSegment === UrlPath.ResetPassword ||
-      pathSegment === UrlPath.Login;
+      pathSegment === UrlPath.ResetPassword || pathSegment === UrlPath.Login;
 
     if (skipRoleCheck || request.body.organizationType !== undefined) {
       return;

--- a/apps/drec-api/src/lib/helpers/parseMetadata.ts
+++ b/apps/drec-api/src/lib/helpers/parseMetadata.ts
@@ -5,7 +5,10 @@ export const parseMetadata = (
     if (typeof metadata !== 'string') return metadata;
     return JSON.parse(metadata);
   } catch (e) {
-    console.error(e, `certificate doesnt contains valid metadata ${JSON.stringify(metadata)}`);
+    console.error(
+      e,
+      `certificate doesnt contains valid metadata ${JSON.stringify(metadata)}`,
+    );
     return null;
   }
 };

--- a/apps/drec-api/src/pods/bulk-upload/bulk-upload.controller.ts
+++ b/apps/drec-api/src/pods/bulk-upload/bulk-upload.controller.ts
@@ -147,7 +147,11 @@ export class BulkUploadController {
     console.log('[BULK-UPLOAD] resolved organizationId', organizationId);
 
     const organization = await this.organizationService.findOne(organizationId);
-    console.log('[BULK-UPLOAD] org found', organization?.id, organization?.organizationType);
+    console.log(
+      '[BULK-UPLOAD] org found',
+      organization?.id,
+      organization?.organizationType,
+    );
     if (organization.organizationType !== OrganizationType.Registrant) {
       console.log('[BULK-UPLOAD] org not Registrant, rejecting');
       throw new UnauthorizedException(
@@ -182,7 +186,12 @@ export class BulkUploadController {
       organizationId,
       bulkUploadType,
     );
-    console.log('[BULK-UPLOAD] job created, id=', job?.id, 'jobId=', (job as any)?.jobId);
+    console.log(
+      '[BULK-UPLOAD] job created, id=',
+      job?.id,
+      'jobId=',
+      (job as any)?.jobId,
+    );
     return job;
   }
 
@@ -338,7 +347,12 @@ export class BulkUploadController {
   async getPreview(
     @Param('bulkUploadId') bulkUploadId: string,
     @UserDecorator() user: ILoggedInUser,
-  ): Promise<{ records: any[]; organizationId: number; totalCsvRows: number; skippedRows: number }> {
+  ): Promise<{
+    records: any[];
+    organizationId: number;
+    totalCsvRows: number;
+    skippedRows: number;
+  }> {
     const { records, organizationId, totalCsvRows, skippedRows } =
       await this.bulkUploadService.getBulkUploadPreview(bulkUploadId);
     await this.bulkUploadService.canManageBulkUploadJobs({
@@ -384,8 +398,7 @@ export class BulkUploadController {
   @Roles(Role.Admin, Role.SiteOperator, Role.Registrant)
   @ApiOperation({
     summary: 'Discard a staged bulk upload',
-    description:
-      'Deletes the staged preview without inserting any devices.',
+    description: 'Deletes the staged preview without inserting any devices.',
   })
   async discard(
     @Param('bulkUploadId') bulkUploadId: string,

--- a/apps/drec-api/src/pods/bulk-upload/bulk-upload.service.ts
+++ b/apps/drec-api/src/pods/bulk-upload/bulk-upload.service.ts
@@ -65,9 +65,7 @@ export class BulkUploadService {
       };
       const s3Upload = await this.fileService.upload(multerFile);
 
-      const contentHash = createHash('sha256')
-        .update(file.data)
-        .digest('hex');
+      const contentHash = createHash('sha256').update(file.data).digest('hex');
 
       const jobId = await this.createJob(bulkUploadType, file, s3Upload);
 

--- a/apps/drec-api/src/pods/certificate-log/certificate-log.controller.ts
+++ b/apps/drec-api/src/pods/certificate-log/certificate-log.controller.ts
@@ -6,7 +6,6 @@ import {
   UseGuards,
   ValidationPipe,
   Query,
-  ConflictException,
   BadRequestException,
   Logger,
   Res,

--- a/apps/drec-api/src/pods/certificate-log/certificate-log.service.ts
+++ b/apps/drec-api/src/pods/certificate-log/certificate-log.service.ts
@@ -716,9 +716,7 @@ export class CertificateLogService {
                 }
                 let deviceLog;
                 if (role === 'Registrant') {
-                  if (
-                    group.orgDeviceIds.find((ele) => ele === deviceId)
-                  ) {
+                  if (group.orgDeviceIds.find((ele) => ele === deviceId)) {
                     this.logger.log('oldlog exists for operator device');
                     // const deviceLog =
                     //   await this.getCheckCertificateIssueDateLogForDevice(
@@ -886,9 +884,7 @@ export class CertificateLogService {
                   }
                   let deviceLog;
                   if (role === 'Registrant') {
-                    if (
-                      group.orgDeviceIds.find((ele) => ele === device.id)
-                    ) {
+                    if (group.orgDeviceIds.find((ele) => ele === device.id)) {
                       deviceLog =
                         await this.getCheckCertificateIssueDateLogForDevice(
                           parseInt(group.dg_id),

--- a/apps/drec-api/src/pods/chat/chat-webhook.controller.ts
+++ b/apps/drec-api/src/pods/chat/chat-webhook.controller.ts
@@ -34,7 +34,9 @@ function sanitizeWebhook(webhook: ChatWebhook): any {
   return {
     ...rest,
     secret: maskSecret(webhook.secret),
-    userName: user ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() || null : null,
+    userName: user
+      ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() || null
+      : null,
     userEmail: user?.email ?? null,
   };
 }

--- a/apps/drec-api/src/pods/chat/chat-webhook.service.ts
+++ b/apps/drec-api/src/pods/chat/chat-webhook.service.ts
@@ -24,8 +24,7 @@ export class ChatWebhookService {
     organizationId: number | null,
     dto: CreateWebhookDto,
   ): Promise<ChatWebhook> {
-    const secret =
-      dto.secret || crypto.randomBytes(32).toString('hex');
+    const secret = dto.secret || crypto.randomBytes(32).toString('hex');
 
     const webhook = this.webhookRepository.create({
       userId,
@@ -70,11 +69,7 @@ export class ChatWebhookService {
   async remove(id: number): Promise<void> {
     const webhook = await this.findOne(id);
     await this.webhookRepository.remove(webhook);
-    typedLog(
-      this.logger,
-      'chat',
-      `Webhook ${id} deleted`,
-    );
+    typedLog(this.logger, 'chat', `Webhook ${id} deleted`);
   }
 
   async dispatch(event: string, payload: Record<string, any>): Promise<void> {

--- a/apps/drec-api/src/pods/chat/chat.controller.ts
+++ b/apps/drec-api/src/pods/chat/chat.controller.ts
@@ -137,9 +137,7 @@ export class ChatController {
 
   @Get('unread-devices/:email')
   @ApiOperation({ summary: 'Get device site names with unread messages' })
-  async getUnreadDeviceNames(
-    @Param('email') email: string,
-  ): Promise<string[]> {
+  async getUnreadDeviceNames(@Param('email') email: string): Promise<string[]> {
     return this.chatService.getUnreadDeviceNames(email);
   }
 

--- a/apps/drec-api/src/pods/chat/chat.service.ts
+++ b/apps/drec-api/src/pods/chat/chat.service.ts
@@ -273,14 +273,10 @@ export class ChatService {
     // (a message exists after their lastReadAt)
     const rows = await this.conversationRepository
       .createQueryBuilder('conv')
-      .innerJoin(
-        Chat,
-        'latest',
-        'latest.uuid = conv."lastEntryUuid"',
-      )
+      .innerJoin(Chat, 'latest', 'latest.uuid = conv."lastEntryUuid"')
       .where(
         '(conv.participant1 = :email AND latest."createdAt" > COALESCE(conv."lastReadAt1", \'1970-01-01\')) OR ' +
-        '(conv.participant2 = :email AND latest."createdAt" > COALESCE(conv."lastReadAt2", \'1970-01-01\'))',
+          '(conv.participant2 = :email AND latest."createdAt" > COALESCE(conv."lastReadAt2", \'1970-01-01\'))',
         { email },
       )
       // Exclude conversations where the latest message is from the user themselves
@@ -316,16 +312,12 @@ export class ChatService {
   async getUnreadDeviceNames(email: string): Promise<string[]> {
     const rows = await this.conversationRepository
       .createQueryBuilder('conv')
-      .innerJoin(
-        Chat,
-        'latest',
-        'latest.uuid = conv."lastEntryUuid"',
-      )
+      .innerJoin(Chat, 'latest', 'latest.uuid = conv."lastEntryUuid"')
       .select('conv."deviceSiteName"', 'deviceSiteName')
       .where('conv."deviceSiteName" IS NOT NULL')
       .andWhere(
         '(conv.participant1 = :email AND latest."createdAt" > COALESCE(conv."lastReadAt1", \'1970-01-01\')) OR ' +
-        '(conv.participant2 = :email AND latest."createdAt" > COALESCE(conv."lastReadAt2", \'1970-01-01\'))',
+          '(conv.participant2 = :email AND latest."createdAt" > COALESCE(conv."lastReadAt2", \'1970-01-01\'))',
         { email },
       )
       .andWhere('latest.username != :email', { email })

--- a/apps/drec-api/src/pods/device-group/buyer-reservation.controller.ts
+++ b/apps/drec-api/src/pods/device-group/buyer-reservation.controller.ts
@@ -181,7 +181,8 @@ export class BuyerReservationController {
           );
           throw new UnauthorizedException({
             success: false,
-            message: 'An registrant is unauthorized to request for other registrant',
+            message:
+              'An registrant is unauthorized to request for other registrant',
           });
         }
       }
@@ -192,7 +193,8 @@ export class BuyerReservationController {
         );
         throw new UnauthorizedException({
           success: false,
-          message: 'The requested organization is not belongs to the registrant',
+          message:
+            'The requested organization is not belongs to the registrant',
         });
       }
     }
@@ -589,10 +591,7 @@ export class BuyerReservationController {
     @Body('status') status: GroupReviewStatus,
   ): Promise<DeviceGroupDTO> {
     this.logger.verbose(`With in updateGroupReviewStatus`);
-    if (
-      !status ||
-      !Object.values(GroupReviewStatus).includes(status)
-    ) {
+    if (!status || !Object.values(GroupReviewStatus).includes(status)) {
       throw new BadRequestException({
         success: false,
         message: `Invalid review status. Must be one of: ${Object.values(GroupReviewStatus).join(', ')}`,

--- a/apps/drec-api/src/pods/device-group/device-bulk-upload.processor.ts
+++ b/apps/drec-api/src/pods/device-group/device-bulk-upload.processor.ts
@@ -9,8 +9,6 @@ import {
 } from '../bulk-upload/bulk-uploads.entity';
 import { DeviceGroupService } from './device-group.service';
 import { Queues } from '../../utils/enums/queues.enum';
-import { DeviceFiles } from '../device/dto';
-import { DocumentType } from '../document-uploads/entities/documents.entity';
 
 @Processor(Queues.DeviceBulkUpload)
 export class DeviceBulkUploadProcessor {
@@ -42,17 +40,6 @@ export class DeviceBulkUploadProcessor {
     this.logger.log(
       `[BULK-TIMING] jobId=${job.id} bulkUpload lookup=${Date.now() - tLookup}ms`,
     );
-    const files: DeviceFiles = {
-      [DocumentType.FORM_SF_02]: [],
-      [DocumentType.SF_02C]: [],
-      [DocumentType.SF_02C_OWNERS_DECLARATION]: [],
-      [DocumentType.METERING_EVIDENCE]: [],
-      [DocumentType.SINGLE_LINE_DIAGRAM]: [],
-      [DocumentType.PROJECT_PHOTOS]: [],
-      [DocumentType.COD_PROOF]: [],
-      [DocumentType.OTHER_DOCUMENTS]: [],
-    };
-
     if (!bulkUpload) {
       this.logger.error(`Bulk upload not found for jobId: ${job.id}`);
       return;
@@ -68,7 +55,6 @@ export class DeviceBulkUploadProcessor {
         fileContent,
         bulkUpload.organizationId,
         bulkUpload,
-        files,
       );
       this.logger.log(
         `[BULK-TIMING] jobId=${job.id} CSV processing=${Date.now() - tCsv}ms, total=${Date.now() - tStart}ms`,

--- a/apps/drec-api/src/pods/device-group/device-group.module.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.module.ts
@@ -57,7 +57,11 @@ import { ReservationExpiryCron } from './reservation-expiry.cron';
     forwardRef(() => BulkUploadModule),
     forwardRef(() => EvidentModule),
   ],
-  providers: [DeviceGroupService, DeviceBulkUploadProcessor, ReservationExpiryCron],
+  providers: [
+    DeviceGroupService,
+    DeviceBulkUploadProcessor,
+    ReservationExpiryCron,
+  ],
   exports: [DeviceGroupService, BullModule],
   controllers: [BuyerReservationController],
 })

--- a/apps/drec-api/src/pods/device-group/device-group.service.spec.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.spec.ts
@@ -327,9 +327,7 @@ describe('DeviceGroupService', () => {
       jest
         .spyOn(userService, 'findByEmail')
         .mockResolvedValue({ role: Role.Registrant } as any);
-      jest
-        .spyOn(service, 'checkDeviceOrganization')
-        .mockResolvedValue(false);
+      jest.spyOn(service, 'checkDeviceOrganization').mockResolvedValue(false);
 
       await expect(service.findById(deviceGroupUid, mockUser)).rejects.toThrow(
         UnauthorizedException,

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -967,7 +967,9 @@ export class DeviceGroupService {
 
     // D-REC §2.6: Screen for date-range overlap against historical issuance records
     if (group.reservationStartDate && group.reservationEndDate) {
-      const deviceExternalIds = devices.map((d) => d.externalId).filter(Boolean);
+      const deviceExternalIds = devices
+        .map((d) => d.externalId)
+        .filter(Boolean);
       if (deviceExternalIds.length > 0) {
         const startDate = new Date(group.reservationStartDate);
         const endDate = new Date(group.reservationEndDate);
@@ -1323,8 +1325,7 @@ export class DeviceGroupService {
       { status: BulkUploadStatus.Importing },
     );
 
-    const organization =
-      await this.organizationService.findOne(organizationId);
+    const organization = await this.organizationService.findOne(organizationId);
     const devicesRegistered = await this.registerCSVBulkDevices(
       organizationId,
       records,
@@ -1385,8 +1386,7 @@ export class DeviceGroupService {
         ele.status = 'Success';
       } else if (
         successfullyAddedRowsAndExternalIds.find(
-          (s) =>
-            s.serialNumber === ele.serialNumber && s.rowNumber === index,
+          (s) => s.serialNumber === ele.serialNumber && s.rowNumber === index,
         )
       ) {
         ele.status = 'Success with validation errors, please update fields';
@@ -1584,7 +1584,10 @@ export class DeviceGroupService {
       new Set(
         devices
           .map((d) =>
-            classifyEvidencePathway(d.operatingConfiguration as any, d.sourceAccessMode as any),
+            classifyEvidencePathway(
+              d.operatingConfiguration as any,
+              d.sourceAccessMode as any,
+            ),
           )
           .filter((p): p is EvidencePathway => p != null),
       ),
@@ -1660,7 +1663,6 @@ export class DeviceGroupService {
     file: Record<string, unknown> | any,
     organizationId: number,
     filesAddedForProcessing: BulkUploadEntity,
-    files: DeviceFiles,
   ): Promise<void | any> {
     this.logger.verbose(`With in processCsvFileAnotherLibrary`);
     this.logger.debug(file.data.Body.toString('utf-8'));
@@ -1678,182 +1680,208 @@ export class DeviceGroupService {
     this.csvStringToJSON(fileData);
 
     return new Promise<void>((resolve, reject) => {
-    CSVToJsonV2()
-      .fromString(fileData)
-      .subscribe(async (data: any) => {
-        rowsConvertedToCsvCount++;
+      CSVToJsonV2()
+        .fromString(fileData)
+        .subscribe(
+          async (data: any) => {
+            rowsConvertedToCsvCount++;
 
-        // Skip the template instruction/placeholder row
-        if (data.serialNumber === 'REPLACE_WITH_DEVICE_SERIAL_NUMBER' ||
-            data.countryCode === '3-letter country code') {
-          skippedRowCount++;
-          return;
-        }
-
-        data.images = [];
-        data.groupId = null;
-
-        // Normalise N/A and whitespace-only values to empty string
-        // so downstream logic treats them as missing.
-        for (const k of Object.keys(data)) {
-          if (typeof data[k] === 'string') {
-            data[k] = data[k].trim();
-            if (data[k].toUpperCase() === 'N/A') {
-              data[k] = '';
-            }
-          }
-        }
-
-        // Legacy template aliasing: older Evident-style CSV templates used
-        // different column names. Map them onto the current DTO field names
-        // if the canonical column isn't present.
-        if (!data.siteName && data.projectName) {
-          data.siteName = data.projectName;
-        }
-        if (!data.serialNumber && data['Evident Device ID']) {
-          data.serialNumber = data['Evident Device ID'];
-        }
-
-        // Synthesize a serial number when the original CSV says
-        // "NOT YET REGISTERED" (or is empty).
-        if (
-          !data.serialNumber ||
-          data.serialNumber.toUpperCase() === 'NOT YET REGISTERED'
-        ) {
-          const sitePart = (data.siteName || data.projectName || 'DEVICE')
-            .toUpperCase()
-            .replace(/[^A-Z0-9]/g, '')
-            .substring(0, 8);
-          data.serialNumber = `${sitePart}ES${String(rowsConvertedToCsvCount).padStart(5, '0')}`;
-        }
-
-        // Defaults for fields the legacy template doesn't include but which
-        // the DTO marks @IsNotEmpty. Registrants are always solar/OMC.
-        if (!data.dataSource) {
-          data.dataSource = 'OMC';
-        }
-        if (!data.dataSourceBrand) {
-          data.dataSourceBrand = 'OMC';
-        }
-        if (!data.deviceDescription) {
-          data.deviceDescription = DeviceDescription.GroundmountSolar;
-        }
-
-        const dataToStore: NewDeviceDTO = {
-          dataSourceBrand: '',
-          externalId: '',
-          siteName: '',
-          address: '',
-          latitude: '',
-          longitude: '',
-          countryCode: '',
-          fuelCode: FuelCode.ES100,
-          deviceTypeCode: DeviceTypeCode.TC150,
-          capacity: 0,
-          commissioningDate: '',
-          gridInterconnection: false,
-          offTaker: OffTaker.Commercial,
-          impactStory: '',
-          images: [],
-          deviceDescription: DeviceDescription.GroundmountSolar,
-          SDGBenefits: [],
-          version: '1.0',
-          dataSource: '',
-          otherDataSource: '',
-          serialNumber: '',
-        };
-        for (const key in dataToStore) {
-          if (key === 'SDGBenefits' || key === 'version') {
-            continue;
-          }
-          if (typeof dataToStore[key] === 'string') {
-            dataToStore[key] = data[key] ?? dataToStore[key];
-          } else if (typeof dataToStore[key] === 'boolean') {
-            dataToStore[key] = data[key]
-              ? String(data[key]).toLowerCase() === 'true'
-              : dataToStore[key];
-          } else if (typeof dataToStore[key] === 'number') {
-            const parsed = parseFloat(data[key]);
-            dataToStore[key] = Number.isNaN(parsed)
-              ? dataToStore[key]
-              : parsed;
-            if (key == 'yieldValue' && dataToStore[key] === 0) {
-              dataToStore[key] = 2000;
-            }
-          }
-          if (key == 'yieldValue' && data.countryCode) {
-            const yieldByCountryCode =
-              await this.yieldConfigService.findByCountryCode(data.countryCode);
-            if (yieldByCountryCode) {
-              dataToStore.yieldValue = yieldByCountryCode.yieldValue;
-            }
-          }
-        }
-        for (const key in dataToStore) {
-          if (dataToStore[key] === '') {
-            dataToStore[key] = null;
-          }
-        }
-        records.push(plainToClass(NewDeviceDTO, dataToStore));
-        recordsErrors.push({
-          serialNumber: '',
-          rowNumber: rowsConvertedToCsvCount,
-          isError: false,
-          errorsList: [],
-        });
-      }, (err: any) => {
-        this.logger.error(`CSV parse error: ${err?.message || err}`);
-        reject(err);
-      })
-      .on('done', async () => {
-        try {
-        // Auto-deduplicate serial numbers within the batch by appending -2, -3, etc.
-        const snCount: Record<string, number> = {};
-        for (const rec of records) {
-          const key = (rec.serialNumber || '').toLowerCase();
-          snCount[key] = (snCount[key] || 0) + 1;
-          if (snCount[key] > 1) {
-            rec.serialNumber = `${rec.serialNumber}-${snCount[key]}`;
-          }
-        }
-
-        for (let index = 0; index < records.length; index++) {
-          const singleRecord = records[index];
-          if (records[index].externalId) {
-            records[index].externalId = records[index].externalId.trim();
-          }
-          const errors = await validate(singleRecord);
-          if (errors.length > 0) {
-            errors?.forEach((ele) => {
-              delete ele.target;
-              delete ele.children;
-            });
-            recordsErrors[index] = {
-              serialNumber: records[index].serialNumber,
-              rowNumber: index,
-              isError: true,
-              errorsList: errors,
-            };
-          } else {
-            recordsErrors[index] = {
-              serialNumber: records[index].serialNumber,
-              rowNumber: index,
-              isError: false,
-              errorsList: errors,
-            };
-          }
-          if (singleRecord.countryCode != undefined) {
-            singleRecord.countryCode = singleRecord.countryCode.toUpperCase();
+            // Skip the template instruction/placeholder row
             if (
-              singleRecord.countryCode &&
-              typeof singleRecord.countryCode === 'string' &&
-              singleRecord.countryCode.length === 3
+              data.serialNumber === 'REPLACE_WITH_DEVICE_SERIAL_NUMBER' ||
+              data.countryCode === '3-letter country code'
             ) {
-              if (
-                countryCodesList.find(
-                  (ele) => ele.countryCode === singleRecord.countryCode,
-                ) === undefined
-              ) {
+              skippedRowCount++;
+              return;
+            }
+
+            data.images = [];
+            data.groupId = null;
+
+            // Normalise N/A and whitespace-only values to empty string
+            // so downstream logic treats them as missing.
+            for (const k of Object.keys(data)) {
+              if (typeof data[k] === 'string') {
+                data[k] = data[k].trim();
+                if (data[k].toUpperCase() === 'N/A') {
+                  data[k] = '';
+                }
+              }
+            }
+
+            // Legacy template aliasing: older Evident-style CSV templates used
+            // different column names. Map them onto the current DTO field names
+            // if the canonical column isn't present.
+            if (!data.siteName && data.projectName) {
+              data.siteName = data.projectName;
+            }
+            if (!data.serialNumber && data['Evident Device ID']) {
+              data.serialNumber = data['Evident Device ID'];
+            }
+
+            // Synthesize a serial number when the original CSV says
+            // "NOT YET REGISTERED" (or is empty).
+            if (
+              !data.serialNumber ||
+              data.serialNumber.toUpperCase() === 'NOT YET REGISTERED'
+            ) {
+              const sitePart = (data.siteName || data.projectName || 'DEVICE')
+                .toUpperCase()
+                .replace(/[^A-Z0-9]/g, '')
+                .substring(0, 8);
+              data.serialNumber = `${sitePart}ES${String(rowsConvertedToCsvCount).padStart(5, '0')}`;
+            }
+
+            // Defaults for fields the legacy template doesn't include but which
+            // the DTO marks @IsNotEmpty. Registrants are always solar/OMC.
+            if (!data.dataSource) {
+              data.dataSource = 'OMC';
+            }
+            if (!data.dataSourceBrand) {
+              data.dataSourceBrand = 'OMC';
+            }
+            if (!data.deviceDescription) {
+              data.deviceDescription = DeviceDescription.GroundmountSolar;
+            }
+
+            const dataToStore: NewDeviceDTO = {
+              dataSourceBrand: '',
+              externalId: '',
+              siteName: '',
+              address: '',
+              latitude: '',
+              longitude: '',
+              countryCode: '',
+              fuelCode: FuelCode.ES100,
+              deviceTypeCode: DeviceTypeCode.TC150,
+              capacity: 0,
+              commissioningDate: '',
+              gridInterconnection: false,
+              offTaker: OffTaker.Commercial,
+              impactStory: '',
+              images: [],
+              deviceDescription: DeviceDescription.GroundmountSolar,
+              SDGBenefits: [],
+              version: '1.0',
+              dataSource: '',
+              otherDataSource: '',
+              serialNumber: '',
+            };
+            for (const key in dataToStore) {
+              if (key === 'SDGBenefits' || key === 'version') {
+                continue;
+              }
+              if (typeof dataToStore[key] === 'string') {
+                dataToStore[key] = data[key] ?? dataToStore[key];
+              } else if (typeof dataToStore[key] === 'boolean') {
+                dataToStore[key] = data[key]
+                  ? String(data[key]).toLowerCase() === 'true'
+                  : dataToStore[key];
+              } else if (typeof dataToStore[key] === 'number') {
+                const parsed = parseFloat(data[key]);
+                dataToStore[key] = Number.isNaN(parsed)
+                  ? dataToStore[key]
+                  : parsed;
+                if (key == 'yieldValue' && dataToStore[key] === 0) {
+                  dataToStore[key] = 2000;
+                }
+              }
+              if (key == 'yieldValue' && data.countryCode) {
+                const yieldByCountryCode =
+                  await this.yieldConfigService.findByCountryCode(
+                    data.countryCode,
+                  );
+                if (yieldByCountryCode) {
+                  dataToStore.yieldValue = yieldByCountryCode.yieldValue;
+                }
+              }
+            }
+            for (const key in dataToStore) {
+              if (dataToStore[key] === '') {
+                dataToStore[key] = null;
+              }
+            }
+            records.push(plainToClass(NewDeviceDTO, dataToStore));
+            recordsErrors.push({
+              serialNumber: '',
+              rowNumber: rowsConvertedToCsvCount,
+              isError: false,
+              errorsList: [],
+            });
+          },
+          (err: any) => {
+            this.logger.error(`CSV parse error: ${err?.message || err}`);
+            reject(err);
+          },
+        )
+        .on('done', async () => {
+          try {
+            // Auto-deduplicate serial numbers within the batch by appending -2, -3, etc.
+            const snCount: Record<string, number> = {};
+            for (const rec of records) {
+              const key = (rec.serialNumber || '').toLowerCase();
+              snCount[key] = (snCount[key] || 0) + 1;
+              if (snCount[key] > 1) {
+                rec.serialNumber = `${rec.serialNumber}-${snCount[key]}`;
+              }
+            }
+
+            for (let index = 0; index < records.length; index++) {
+              const singleRecord = records[index];
+              if (records[index].externalId) {
+                records[index].externalId = records[index].externalId.trim();
+              }
+              const errors = await validate(singleRecord);
+              if (errors.length > 0) {
+                errors?.forEach((ele) => {
+                  delete ele.target;
+                  delete ele.children;
+                });
+                recordsErrors[index] = {
+                  serialNumber: records[index].serialNumber,
+                  rowNumber: index,
+                  isError: true,
+                  errorsList: errors,
+                };
+              } else {
+                recordsErrors[index] = {
+                  serialNumber: records[index].serialNumber,
+                  rowNumber: index,
+                  isError: false,
+                  errorsList: errors,
+                };
+              }
+              if (singleRecord.countryCode != undefined) {
+                singleRecord.countryCode =
+                  singleRecord.countryCode.toUpperCase();
+                if (
+                  singleRecord.countryCode &&
+                  typeof singleRecord.countryCode === 'string' &&
+                  singleRecord.countryCode.length === 3
+                ) {
+                  if (
+                    countryCodesList.find(
+                      (ele) => ele.countryCode === singleRecord.countryCode,
+                    ) === undefined
+                  ) {
+                    recordsErrors[index].isError = true;
+                    recordsErrors[index].errorsList.push({
+                      value: singleRecord.countryCode,
+                      property: 'countryCode',
+                      constraints: {
+                        invalidCountryCode: 'Invalid countryCode',
+                      },
+                    });
+                  }
+                } else {
+                  recordsErrors[index].isError = true;
+                  recordsErrors[index].errorsList.push({
+                    value: singleRecord.countryCode,
+                    property: 'countryCode',
+                    constraints: { invalidCountryCode: 'Invalid countryCode' },
+                  });
+                }
+              } else {
                 recordsErrors[index].isError = true;
                 recordsErrors[index].errorsList.push({
                   value: singleRecord.countryCode,
@@ -1861,242 +1889,229 @@ export class DeviceGroupService {
                   constraints: { invalidCountryCode: 'Invalid countryCode' },
                 });
               }
-            } else {
-              recordsErrors[index].isError = true;
-              recordsErrors[index].errorsList.push({
-                value: singleRecord.countryCode,
-                property: 'countryCode',
-                constraints: { invalidCountryCode: 'Invalid countryCode' },
-              });
-            }
-          } else {
-            recordsErrors[index].isError = true;
-            recordsErrors[index].errorsList.push({
-              value: singleRecord.countryCode,
-              property: 'countryCode',
-              constraints: { invalidCountryCode: 'Invalid countryCode' },
-            });
-          }
-          if (
-            singleRecord.commissioningDate &&
-            typeof singleRecord.commissioningDate === 'string'
-          ) {
-            this.logger.debug(
-              !isValidUTCDateFormat(singleRecord.commissioningDate),
-            );
-            if (!isValidUTCDateFormat(singleRecord.commissioningDate)) {
-              const hasValidSeconds =
-                moment(singleRecord.commissioningDate).seconds() < 60;
-              const hasValidMinutes =
-                moment(singleRecord.commissioningDate).minutes() < 60;
-              recordsErrors[index].isError = true;
-              if (!hasValidMinutes) {
-                recordsErrors[index].errorsList.push({
-                  value: singleRecord.commissioningDate,
-                  property: 'commissioningDate',
-                  constraints: { invalidDate: 'Invalid minutes value.' },
-                });
-              } else if (!hasValidSeconds) {
-                recordsErrors[index].errorsList.push({
-                  value: singleRecord.commissioningDate,
-                  property: 'commissioningDate',
-                  constraints: { invalidDate: 'Invalid seconds value.' },
-                });
-              }
-              recordsErrors[index].errorsList.push({
-                value: singleRecord.commissioningDate,
-                property: 'commissioningDate',
-                constraints: {
-                  invalidDate:
-                    'Invalid commission date sent.Format is YYYY-MM-DDThh:mm:ss.millisecondsZ example 2022-10-18T11:35:27.640Z',
-                },
-              });
-            }
-            if (
-              new Date(singleRecord.commissioningDate).getTime() >
-              new Date().getTime()
-            ) {
-              recordsErrors[index].isError = true;
-              recordsErrors[index].errorsList.push({
-                value: singleRecord.commissioningDate,
-                property: 'commissioningDate',
-                constraints: {
-                  invalidDate:
-                    'Invalid commissioning date, commissioning is greater than current date',
-                },
-              });
-            }
-          }
-          if (singleRecord.capacity <= 0) {
-            recordsErrors[index].isError = true;
-            recordsErrors[index].errorsList.push({
-              value: singleRecord.capacity,
-              property: 'capacity',
-              constraints: {
-                greaterThanZero: 'Capacity should be greater than 0',
-              },
-            });
-          }
-        }
-
-        records?.forEach((singleRecord, index) => {
-          recordsErrors[index].errorsList?.forEach((error) => {
-            singleRecord[error.property] = null; //making null field if it has any validation issue
-          });
-        });
-        const listOfExistingDevices = await this.checkIfDeviceExisting(
-          records,
-          organizationId,
-        );
-
-        if (listOfExistingDevices.length > 0) {
-          records?.forEach((singleRecord, index) => {
-            if (
-              listOfExistingDevices.find(
-                (ele) => ele === singleRecord.externalId,
-              )
-            ) {
-              recordsErrors[index].isError = true;
-              recordsErrors[index].errorsList.push({
-                value: singleRecord.serialNumber,
-                property: 'serialNumber',
-                constraints: {
-                  serialNumberExists:
-                    'serialNumber already exist, cant add entry with same serial number',
-                },
-              });
-            }
-          });
-        }
-
-        // Bulk siteName pre-check so we catch all conflicts up front.
-        // register() also checks siteName per-row, but that only fires during
-        // insertion — we need the error surfaced here to honor atomicity.
-        const existingSiteNames =
-          await this.deviceService.findMultipleDevicesBasedSiteName(
-            records.map((r) => r.siteName).filter(Boolean) as string[],
-            organizationId,
-          );
-        if (existingSiteNames.length > 0) {
-          const existingSet = new Set(existingSiteNames);
-          records?.forEach((singleRecord, index) => {
-            if (singleRecord.siteName && existingSet.has(singleRecord.siteName)) {
-              recordsErrors[index].isError = true;
-              recordsErrors[index].errorsList.push({
-                value: singleRecord.siteName,
-                property: 'siteName',
-                constraints: {
-                  siteNameExists: `A device with site name "${singleRecord.siteName}" already exists in this organization`,
-                },
-              });
-            }
-          });
-        }
-        const recordsCopy = cloneDeep(records);
-        recordsCopy.forEach((ele) => (ele['statusDuplicate'] = false));
-        const duplicateserialNumbers: any = [];
-        for (let i = 0; i < recordsCopy.length - 1; i++) {
-          this.logger.debug(recordsCopy[i].serialNumber);
-          for (let j = i + 1; j < recordsCopy.length; j++) {
-            this.logger.debug(recordsCopy[j].serialNumber);
-            if (
-              recordsCopy[i].serialNumber != null &&
-              recordsCopy[j].serialNumber != null
-            ) {
               if (
-                recordsCopy[i].serialNumber.toLowerCase() ===
-                  recordsCopy[j].serialNumber.toLowerCase() &&
-                recordsCopy[j]['statusDuplicate'] === false
+                singleRecord.commissioningDate &&
+                typeof singleRecord.commissioningDate === 'string'
               ) {
-                recordsCopy[j]['statusDuplicate'] = true;
-                duplicateserialNumbers.push({
-                  duplicateIndex: j,
-                  duplicateWith: i,
-                  siteName: records[j].siteName,
-                  serialNumber: records[j].serialNumber,
-                });
-                recordsErrors[j].isError = true;
-                recordsErrors[j].errorsList.push({
-                  value: recordsCopy[j].serialNumber,
-                  property: 'serialNumber',
+                this.logger.debug(
+                  !isValidUTCDateFormat(singleRecord.commissioningDate),
+                );
+                if (!isValidUTCDateFormat(singleRecord.commissioningDate)) {
+                  const hasValidSeconds =
+                    moment(singleRecord.commissioningDate).seconds() < 60;
+                  const hasValidMinutes =
+                    moment(singleRecord.commissioningDate).minutes() < 60;
+                  recordsErrors[index].isError = true;
+                  if (!hasValidMinutes) {
+                    recordsErrors[index].errorsList.push({
+                      value: singleRecord.commissioningDate,
+                      property: 'commissioningDate',
+                      constraints: { invalidDate: 'Invalid minutes value.' },
+                    });
+                  } else if (!hasValidSeconds) {
+                    recordsErrors[index].errorsList.push({
+                      value: singleRecord.commissioningDate,
+                      property: 'commissioningDate',
+                      constraints: { invalidDate: 'Invalid seconds value.' },
+                    });
+                  }
+                  recordsErrors[index].errorsList.push({
+                    value: singleRecord.commissioningDate,
+                    property: 'commissioningDate',
+                    constraints: {
+                      invalidDate:
+                        'Invalid commission date sent.Format is YYYY-MM-DDThh:mm:ss.millisecondsZ example 2022-10-18T11:35:27.640Z',
+                    },
+                  });
+                }
+                if (
+                  new Date(singleRecord.commissioningDate).getTime() >
+                  new Date().getTime()
+                ) {
+                  recordsErrors[index].isError = true;
+                  recordsErrors[index].errorsList.push({
+                    value: singleRecord.commissioningDate,
+                    property: 'commissioningDate',
+                    constraints: {
+                      invalidDate:
+                        'Invalid commissioning date, commissioning is greater than current date',
+                    },
+                  });
+                }
+              }
+              if (singleRecord.capacity <= 0) {
+                recordsErrors[index].isError = true;
+                recordsErrors[index].errorsList.push({
+                  value: singleRecord.capacity,
+                  property: 'capacity',
                   constraints: {
-                    externalIdExists:
-                      'Row ' +
-                      (j + 1) +
-                      ' Duplicate with row ' +
-                      (i + 1) +
-                      ' Exists with serialNumber ' +
-                      records[j].serialNumber,
+                    greaterThanZero: 'Capacity should be greater than 0',
                   },
                 });
               }
             }
-          }
-        }
 
-        const successfullyAddedRowsAndExternalIds: Array<{
-          rowNumber: number;
-          serialNumber: string;
-        }> = [];
-
-        // Atomic pre-flight: if ANY row has an error after all validation
-        // and conflict checks, abort the entire upload without inserting
-        // anything. Keeps the DB consistent with the user's CSV — partial
-        // imports leave orphan rows that block re-upload.
-        const anyError = recordsErrors.some((r) => r.errorsList.length > 0);
-        if (anyError) {
-          recordsErrors.forEach((r, idx) => {
-            if (r.errorsList.length === 0) {
-              r.isError = true;
-              r.errorsList.push({
-                value: records[idx].serialNumber,
-                property: 'batch',
-                constraints: {
-                  batchAborted:
-                    'Row skipped: other rows in this upload had errors. The whole batch was rejected to keep the upload atomic.',
-                },
+            records?.forEach((singleRecord, index) => {
+              recordsErrors[index].errorsList?.forEach((error) => {
+                singleRecord[error.property] = null; //making null field if it has any validation issue
               });
-            }
-          });
-          await this.bulkUploadRepository.update(
-            { jobId: filesAddedForProcessing.jobId },
-            { status: BulkUploadStatus.Failed },
-          );
-          this.createFailedRowDetailsForCSVJob(
-            filesAddedForProcessing.id,
-            recordsErrors,
-            successfullyAddedRowsAndExternalIds,
-          );
-          resolve();
-          return;
-        }
-
-        // Validation passed for all rows. Stop here and stage the parsed
-        // records as a preview. The user reviews the list, then hits the
-        // confirm endpoint to actually insert them.
-        await this.bulkUploadFailedLogRepository.save({
-          bulkUploadId: filesAddedForProcessing.id,
-          details: {
-            preview: {
+            });
+            const listOfExistingDevices = await this.checkIfDeviceExisting(
               records,
               organizationId,
-              totalCsvRows: rowsConvertedToCsvCount,
-              skippedRows: skippedRowCount,
-            },
-          },
+            );
+
+            if (listOfExistingDevices.length > 0) {
+              records?.forEach((singleRecord, index) => {
+                if (
+                  listOfExistingDevices.find(
+                    (ele) => ele === singleRecord.externalId,
+                  )
+                ) {
+                  recordsErrors[index].isError = true;
+                  recordsErrors[index].errorsList.push({
+                    value: singleRecord.serialNumber,
+                    property: 'serialNumber',
+                    constraints: {
+                      serialNumberExists:
+                        'serialNumber already exist, cant add entry with same serial number',
+                    },
+                  });
+                }
+              });
+            }
+
+            // Bulk siteName pre-check so we catch all conflicts up front.
+            // register() also checks siteName per-row, but that only fires during
+            // insertion — we need the error surfaced here to honor atomicity.
+            const existingSiteNames =
+              await this.deviceService.findMultipleDevicesBasedSiteName(
+                records.map((r) => r.siteName).filter(Boolean) as string[],
+                organizationId,
+              );
+            if (existingSiteNames.length > 0) {
+              const existingSet = new Set(existingSiteNames);
+              records?.forEach((singleRecord, index) => {
+                if (
+                  singleRecord.siteName &&
+                  existingSet.has(singleRecord.siteName)
+                ) {
+                  recordsErrors[index].isError = true;
+                  recordsErrors[index].errorsList.push({
+                    value: singleRecord.siteName,
+                    property: 'siteName',
+                    constraints: {
+                      siteNameExists: `A device with site name "${singleRecord.siteName}" already exists in this organization`,
+                    },
+                  });
+                }
+              });
+            }
+            const recordsCopy = cloneDeep(records);
+            recordsCopy.forEach((ele) => (ele['statusDuplicate'] = false));
+            const duplicateserialNumbers: any = [];
+            for (let i = 0; i < recordsCopy.length - 1; i++) {
+              this.logger.debug(recordsCopy[i].serialNumber);
+              for (let j = i + 1; j < recordsCopy.length; j++) {
+                this.logger.debug(recordsCopy[j].serialNumber);
+                if (
+                  recordsCopy[i].serialNumber != null &&
+                  recordsCopy[j].serialNumber != null
+                ) {
+                  if (
+                    recordsCopy[i].serialNumber.toLowerCase() ===
+                      recordsCopy[j].serialNumber.toLowerCase() &&
+                    recordsCopy[j]['statusDuplicate'] === false
+                  ) {
+                    recordsCopy[j]['statusDuplicate'] = true;
+                    duplicateserialNumbers.push({
+                      duplicateIndex: j,
+                      duplicateWith: i,
+                      siteName: records[j].siteName,
+                      serialNumber: records[j].serialNumber,
+                    });
+                    recordsErrors[j].isError = true;
+                    recordsErrors[j].errorsList.push({
+                      value: recordsCopy[j].serialNumber,
+                      property: 'serialNumber',
+                      constraints: {
+                        externalIdExists:
+                          'Row ' +
+                          (j + 1) +
+                          ' Duplicate with row ' +
+                          (i + 1) +
+                          ' Exists with serialNumber ' +
+                          records[j].serialNumber,
+                      },
+                    });
+                  }
+                }
+              }
+            }
+
+            const successfullyAddedRowsAndExternalIds: Array<{
+              rowNumber: number;
+              serialNumber: string;
+            }> = [];
+
+            // Atomic pre-flight: if ANY row has an error after all validation
+            // and conflict checks, abort the entire upload without inserting
+            // anything. Keeps the DB consistent with the user's CSV — partial
+            // imports leave orphan rows that block re-upload.
+            const anyError = recordsErrors.some((r) => r.errorsList.length > 0);
+            if (anyError) {
+              recordsErrors.forEach((r, idx) => {
+                if (r.errorsList.length === 0) {
+                  r.isError = true;
+                  r.errorsList.push({
+                    value: records[idx].serialNumber,
+                    property: 'batch',
+                    constraints: {
+                      batchAborted:
+                        'Row skipped: other rows in this upload had errors. The whole batch was rejected to keep the upload atomic.',
+                    },
+                  });
+                }
+              });
+              await this.bulkUploadRepository.update(
+                { jobId: filesAddedForProcessing.jobId },
+                { status: BulkUploadStatus.Failed },
+              );
+              this.createFailedRowDetailsForCSVJob(
+                filesAddedForProcessing.id,
+                recordsErrors,
+                successfullyAddedRowsAndExternalIds,
+              );
+              resolve();
+              return;
+            }
+
+            // Validation passed for all rows. Stop here and stage the parsed
+            // records as a preview. The user reviews the list, then hits the
+            // confirm endpoint to actually insert them.
+            await this.bulkUploadFailedLogRepository.save({
+              bulkUploadId: filesAddedForProcessing.id,
+              details: {
+                preview: {
+                  records,
+                  organizationId,
+                  totalCsvRows: rowsConvertedToCsvCount,
+                  skippedRows: skippedRowCount,
+                },
+              },
+            });
+            await this.bulkUploadRepository.update(
+              { jobId: filesAddedForProcessing.jobId },
+              { status: BulkUploadStatus.PendingConfirmation },
+            );
+            resolve();
+          } catch (err) {
+            this.logger.error(
+              `processCsvFileAnotherLibrary done-handler failed: ${err?.stack || err}`,
+            );
+            reject(err);
+          }
         });
-        await this.bulkUploadRepository.update(
-          { jobId: filesAddedForProcessing.jobId },
-          { status: BulkUploadStatus.PendingConfirmation },
-        );
-        resolve();
-        } catch (err) {
-          this.logger.error(
-            `processCsvFileAnotherLibrary done-handler failed: ${err?.stack || err}`,
-          );
-          reject(err);
-        }
-      });
     });
   }
 
@@ -2535,10 +2550,7 @@ export class DeviceGroupService {
         whereOrganizationId = qb.where(`dg.api_user_id = :api_user_id`, {
           api_user_id: apiUserId,
         });
-      } else if (
-        role === 'SiteOperator' ||
-        role === 'User'
-      ) {
+      } else if (role === 'SiteOperator' || role === 'User') {
         whereOrganizationId = qb.where(`d.organizationId = :orgId`, {
           orgId: orgId,
         });
@@ -2758,10 +2770,7 @@ export class DeviceGroupService {
         }
         return acc;
       }, []);
-    } else if (
-      role === 'Buyer' ||
-      role === 'SubBuyer'
-    ) {
+    } else if (role === 'Buyer' || role === 'SubBuyer') {
       deviceGroups = groupedData.reduce((acc, curr) => {
         const existing = acc.find((item) => item.dg_id === curr.devicegroupuid);
 
@@ -2829,10 +2838,7 @@ export class DeviceGroupService {
         whereOrganizationId = qb.where(`dg.api_user_id = :api_user_id`, {
           api_user_id: apiUserId,
         });
-      } else if (
-        role === 'SiteOperator' ||
-        role === 'User'
-      ) {
+      } else if (role === 'SiteOperator' || role === 'User') {
         whereOrganizationId = qb.where(`d.organizationId = :orgId`, {
           orgId: orgId,
         });
@@ -3048,10 +3054,7 @@ export class DeviceGroupService {
         }
         return acc;
       }, []);
-    } else if (
-      role === 'Buyer' ||
-      role === 'SubBuyer'
-    ) {
+    } else if (role === 'Buyer' || role === 'SubBuyer') {
       deviceGroups = groupedData.reduce((acc, curr) => {
         const existing = acc.find((item) => item.dg_id === curr.devicegroupid);
 

--- a/apps/drec-api/src/pods/device-group/reservation-expiry.cron.ts
+++ b/apps/drec-api/src/pods/device-group/reservation-expiry.cron.ts
@@ -14,7 +14,9 @@ export class ReservationExpiryCron {
     this.logger.log('Sweeping expired reservations…');
     const released = await this.groupService.sweepExpiredReservations();
     if (released > 0) {
-      this.logger.log(`Deactivated ${released} expired reservation(s) and released their devices`);
+      this.logger.log(
+        `Deactivated ${released} expired reservation(s) and released their devices`,
+      );
     } else {
       this.logger.debug('No expired reservations found');
     }

--- a/apps/drec-api/src/pods/device-reviews/device-reviews.controller.ts
+++ b/apps/drec-api/src/pods/device-reviews/device-reviews.controller.ts
@@ -121,7 +121,13 @@ export class DeviceReviewsController {
     @Body() body: { readId: number; reason: string; reviewer?: string },
     @Req() req: Request,
   ): Promise<{ logged: boolean }> {
-    return this.service.flagMeterRead(deviceId, body.readId, body.reason, body.reviewer, req.ip);
+    return this.service.flagMeterRead(
+      deviceId,
+      body.readId,
+      body.reason,
+      body.reviewer,
+      req.ip,
+    );
   }
 
   @Post('meter-reads/:deviceId/gap-analysis')
@@ -201,11 +207,15 @@ export class DeviceReviewsController {
   @UseGuards(AuthVerifiedGuard('jwt'), PermissionGuard)
   @Permission('Read')
   @ACLModules('DEVICE_REVIEWS_MANAGEMENT_CRUDL')
-  @ApiOperation({ summary: 'Run auto-screen on multiple devices (or all unscreened)' })
+  @ApiOperation({
+    summary: 'Run auto-screen on multiple devices (or all unscreened)',
+  })
   @ApiResponse({ status: 200, description: 'Screen results per device' })
   bulkAutoScreen(
     @Body('deviceIds') deviceIds?: number[],
-  ): Promise<Array<{ deviceId: number; overallStatus: string; error?: string }>> {
+  ): Promise<
+    Array<{ deviceId: number; overallStatus: string; error?: string }>
+  > {
     return this.service.bulkAutoScreen(deviceIds);
   }
 
@@ -227,9 +237,7 @@ export class DeviceReviewsController {
   @ApiOperation({ summary: 'Delete a document from DB and S3' })
   @ApiResponse({ status: 204, description: 'Document deleted' })
   @ApiResponse({ status: 404, description: 'Document not found' })
-  async deleteDocument(
-    @Param('id', ParseIntPipe) id: number,
-  ): Promise<void> {
+  async deleteDocument(@Param('id', ParseIntPipe) id: number): Promise<void> {
     return this.service.deleteDocument(id);
   }
 
@@ -477,9 +485,7 @@ export class DeviceReviewsController {
       'D-REC VA layer: Aggregates ownership, duplicates, source-access, consistency, ceiling, cross-source, photo GPS, and compensating controls into one report.',
   })
   @ApiResponse({ status: 200, description: 'Auto-screen report' })
-  autoScreen(
-    @Param('deviceId', ParseIntPipe) deviceId: number,
-  ): Promise<any> {
+  autoScreen(@Param('deviceId', ParseIntPipe) deviceId: number): Promise<any> {
     return this.service.autoScreenReport(deviceId);
   }
 
@@ -541,7 +547,10 @@ export class DeviceReviewsController {
     description:
       'Reverse-geocodes the device coordinates and compares to the declared country. Points inside curated disputed-territory polygons are never auto-rejected — they are surfaced for reviewer judgment with both claims shown.',
   })
-  @ApiResponse({ status: 200, description: 'Country match verification result' })
+  @ApiResponse({
+    status: 200,
+    description: 'Country match verification result',
+  })
   verifyCountryMatch(
     @Param('deviceId', ParseIntPipe) deviceId: number,
   ): Promise<any> {
@@ -554,12 +563,11 @@ export class DeviceReviewsController {
   @ACLModules('DEVICE_REVIEWS_MANAGEMENT_CRUDL')
   @ApiOperation({
     summary: 'Preview SF-02 data before generation',
-    description: 'Returns the fields and document status that will be included in the SF-02 registration form.',
+    description:
+      'Returns the fields and document status that will be included in the SF-02 registration form.',
   })
   @ApiResponse({ status: 200, description: 'SF-02 preview data' })
-  previewSf02(
-    @Param('deviceId', ParseIntPipe) deviceId: number,
-  ): Promise<any> {
+  previewSf02(@Param('deviceId', ParseIntPipe) deviceId: number): Promise<any> {
     return this.service.previewSf02(deviceId);
   }
 
@@ -572,7 +580,10 @@ export class DeviceReviewsController {
     description:
       'Creates a PDF registration form from device data, uploads it to S3, and saves it as a FORM_SF_02 document.',
   })
-  @ApiResponse({ status: 201, description: 'Generated SF-02 URL and document ID' })
+  @ApiResponse({
+    status: 201,
+    description: 'Generated SF-02 URL and document ID',
+  })
   generateSf02(
     @Param('deviceId', ParseIntPipe) deviceId: number,
   ): Promise<{ url: string; docId: number }> {

--- a/apps/drec-api/src/pods/device-reviews/device-reviews.service.ts
+++ b/apps/drec-api/src/pods/device-reviews/device-reviews.service.ts
@@ -1218,9 +1218,7 @@ export class DeviceReviewsService {
     );
 
     const gsaYieldPerKw =
-      solarGsa && capacityKw > 0
-        ? solarGsa.annualKwh / capacityKw
-        : undefined;
+      solarGsa && capacityKw > 0 ? solarGsa.annualKwh / capacityKw : undefined;
     const ceilingYield =
       irradiance?.yieldHigh ?? gsaYieldPerKw ?? configuredYield ?? 1500;
     const recentReadings = readRows.map((r: any) => {

--- a/apps/drec-api/src/pods/device/device.controller.ts
+++ b/apps/drec-api/src/pods/device/device.controller.ts
@@ -687,7 +687,8 @@ export class DeviceController {
     @Req() req: Request,
   ): Promise<DeviceDTO> {
     this.logger.verbose(`With in create`);
-    let { organizationId, role, api_user_id } = user;
+    let { organizationId, api_user_id } = user;
+    const { role } = user;
     // Dual-path: multipart sends device data in `deviceToRegister` field;
     // plain JSON sends it directly as the body.
     const deviceToRegister = (
@@ -1077,9 +1078,7 @@ export class DeviceController {
             checkDevice.createdAt,
           );
 
-        if (
-          deviceToUpdate.commissioningDate != checkDevice.commissioningDate
-        ) {
+        if (deviceToUpdate.commissioningDate != checkDevice.commissioningDate) {
           if (noOfHistRead > 0 || noOfOnGoingRead > 0) {
             this.logger.error(
               `Commissioning date cannot be changed due to existing meter reads available for ${checkDevice.serialNumber}`,
@@ -1099,7 +1098,9 @@ export class DeviceController {
       user.organizationId,
     );
     if (!deviceForUpdate) {
-      throw new NotFoundException(`No device found with identifier "${serialNumber}"`);
+      throw new NotFoundException(
+        `No device found with identifier "${serialNumber}"`,
+      );
     }
 
     // Pass the resolved externalId so update()'s inner lookup hits on the first try.

--- a/apps/drec-api/src/pods/device/device.entity.ts
+++ b/apps/drec-api/src/pods/device/device.entity.ts
@@ -15,7 +15,20 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { DeviceDescription, IDevice } from '../../models';
-import { DeviceTypeCode, EvidencePathway, FuelCode, OffTaker, OperatingConfiguration, OwnershipStatus, PublicFundingType, RegistrationType, SourceAccessMode, SubsidyType, VolumeEvidenceType, YesNo } from '../../utils/enums';
+import {
+  DeviceTypeCode,
+  EvidencePathway,
+  FuelCode,
+  OffTaker,
+  OperatingConfiguration,
+  OwnershipStatus,
+  PublicFundingType,
+  RegistrationType,
+  SourceAccessMode,
+  SubsidyType,
+  VolumeEvidenceType,
+  YesNo,
+} from '../../utils/enums';
 import { Organization } from '../organization/organization.entity';
 import { CheckCertificateIssueDateLogForDeviceEntity } from './check_certificate_issue_date_log_for_device.entity';
 import { EvidentRegistrationStatus } from '../../types/evident';
@@ -234,7 +247,11 @@ export class Device extends ExtendedBaseEntity implements IDevice {
   @IsString()
   defaultAccountCode: string | null;
 
-  @Column({ type: 'date', nullable: true, name: 'requested_effective_reg_date' })
+  @Column({
+    type: 'date',
+    nullable: true,
+    name: 'requested_effective_reg_date',
+  })
   requestedEffectiveRegDate: string | null;
 
   // Signature & evidence pathway (Evident checklist rows 55-56, 58-59, 61-62)
@@ -259,11 +276,19 @@ export class Device extends ExtendedBaseEntity implements IDevice {
   @IsEnum(YesNo)
   hasCaptiveConsumer: YesNo | null;
 
-  @Column({ type: 'varchar', nullable: true, name: 'has_auxiliary_energy_sources' })
+  @Column({
+    type: 'varchar',
+    nullable: true,
+    name: 'has_auxiliary_energy_sources',
+  })
   @IsEnum(YesNo)
   hasAuxiliaryEnergySources: YesNo | null;
 
-  @Column({ type: 'varchar', nullable: true, name: 'auxiliary_energy_source_details' })
+  @Column({
+    type: 'varchar',
+    nullable: true,
+    name: 'auxiliary_energy_source_details',
+  })
   @IsString()
   auxiliaryEnergySourceDetails: string | null;
 
@@ -271,7 +296,11 @@ export class Device extends ExtendedBaseEntity implements IDevice {
   @IsString()
   nonMeterImportDetails: string | null;
 
-  @Column({ type: 'text', nullable: true, name: 'other_eac_scheme_registration' })
+  @Column({
+    type: 'text',
+    nullable: true,
+    name: 'other_eac_scheme_registration',
+  })
   @IsString()
   otherEacSchemeRegistration: string | null;
 
@@ -301,7 +330,11 @@ export class Device extends ExtendedBaseEntity implements IDevice {
   @IsString()
   offTakerName: string | null;
 
-  @Column({ type: 'varchar', nullable: true, name: 'off_taker_same_company_as_owner' })
+  @Column({
+    type: 'varchar',
+    nullable: true,
+    name: 'off_taker_same_company_as_owner',
+  })
   @IsEnum(YesNo)
   offTakerSameCompanyAsOwner: YesNo | null;
 
@@ -343,7 +376,11 @@ export class Device extends ExtendedBaseEntity implements IDevice {
   @IsEnum(PublicFundingType)
   publicFundingType: PublicFundingType | null;
 
-  @Column({ type: 'varchar', nullable: true, name: 'labelling_scheme_accreditation' })
+  @Column({
+    type: 'varchar',
+    nullable: true,
+    name: 'labelling_scheme_accreditation',
+  })
   @IsString()
   labellingSchemeAccreditation: string | null;
 
@@ -355,7 +392,12 @@ export class Device extends ExtendedBaseEntity implements IDevice {
   @IsString()
   offGridCircumstances: string | null;
 
-  @Column({ type: 'varchar', length: 10, nullable: true, name: 'last_screen_status' })
+  @Column({
+    type: 'varchar',
+    length: 10,
+    nullable: true,
+    name: 'last_screen_status',
+  })
   lastScreenStatus: string | null;
 
   @Column({ type: 'timestamptz', nullable: true, name: 'last_screened_at' })

--- a/apps/drec-api/src/pods/device/device.service.ts
+++ b/apps/drec-api/src/pods/device/device.service.ts
@@ -140,9 +140,7 @@ export class DeviceService {
    * Screen a device for potential duplicates across all organizations.
    * Checks: coordinate proximity (< 100m), serial number match, fingerprint match.
    */
-  async screenForDuplicates(
-    deviceId: number,
-  ): Promise<{
+  async screenForDuplicates(deviceId: number): Promise<{
     duplicates: Array<{
       id: number;
       externalId: string;
@@ -196,7 +194,10 @@ export class DeviceService {
         [device.latitude, device.longitude, device.id],
       );
       nearbyDevices.forEach((d) =>
-        duplicates.push({ ...d, matchType: `coordinates (${Math.round(d.distance_m)}m)` }),
+        duplicates.push({
+          ...d,
+          matchType: `coordinates (${Math.round(d.distance_m)}m)`,
+        }),
       );
     }
 
@@ -207,7 +208,13 @@ export class DeviceService {
           serialNumber: device.serialNumber,
           id: Not(device.id),
         },
-        select: ['id', 'externalId', 'siteName', 'serialNumber', 'organizationId'],
+        select: [
+          'id',
+          'externalId',
+          'siteName',
+          'serialNumber',
+          'organizationId',
+        ],
       });
       serialMatches.forEach((d) => {
         if (!duplicates.find((dup) => dup.id === d.id)) {
@@ -230,7 +237,13 @@ export class DeviceService {
           fingerprint: device.fingerprint,
           id: Not(device.id),
         },
-        select: ['id', 'externalId', 'siteName', 'serialNumber', 'organizationId'],
+        select: [
+          'id',
+          'externalId',
+          'siteName',
+          'serialNumber',
+          'organizationId',
+        ],
       });
       fpMatches.forEach((d) => {
         if (!duplicates.find((dup) => dup.id === d.id)) {
@@ -875,7 +888,8 @@ export class DeviceService {
         const documentTypes = {
           [DocumentType.FORM_SF_02]: DocumentType.FORM_SF_02,
           [DocumentType.SF_02C]: DocumentType.SF_02C,
-          [DocumentType.SF_02C_OWNERS_DECLARATION]: DocumentType.SF_02C_OWNERS_DECLARATION,
+          [DocumentType.SF_02C_OWNERS_DECLARATION]:
+            DocumentType.SF_02C_OWNERS_DECLARATION,
           [DocumentType.METERING_EVIDENCE]: DocumentType.METERING_EVIDENCE,
           [DocumentType.SINGLE_LINE_DIAGRAM]: DocumentType.SINGLE_LINE_DIAGRAM,
           [DocumentType.PROJECT_PHOTOS]: DocumentType.PROJECT_PHOTOS,
@@ -971,7 +985,9 @@ export class DeviceService {
 
     if (!currentDevice) {
       this.logger.error(`No device found with ${lookupBy} ${serialNumber}`);
-      throw new NotFoundException(`No device found with ${lookupBy} "${serialNumber}"`);
+      throw new NotFoundException(
+        `No device found with ${lookupBy} "${serialNumber}"`,
+      );
     }
 
     if (updateDeviceDTO.siteName) {
@@ -1023,10 +1039,12 @@ export class DeviceService {
     const fingerprint = generateDeviceFingerprint({
       latitude: updateDeviceDTO.latitude ?? currentDevice.latitude,
       longitude: updateDeviceDTO.longitude ?? currentDevice.longitude,
-      commissioningDate: updateDeviceDTO.commissioningDate ?? currentDevice.commissioningDate,
+      commissioningDate:
+        updateDeviceDTO.commissioningDate ?? currentDevice.commissioningDate,
       capacity: updateDeviceDTO.capacity ?? currentDevice.capacity,
       fuelCode: updateDeviceDTO.fuelCode ?? currentDevice.fuelCode,
-      deviceTypeCode: updateDeviceDTO.deviceTypeCode ?? currentDevice.deviceTypeCode,
+      deviceTypeCode:
+        updateDeviceDTO.deviceTypeCode ?? currentDevice.deviceTypeCode,
       serialNumber: updateDeviceDTO.serialNumber ?? currentDevice.serialNumber,
     });
 

--- a/apps/drec-api/src/pods/device/dto/device.dto.ts
+++ b/apps/drec-api/src/pods/device/dto/device.dto.ts
@@ -11,7 +11,18 @@ import {
 } from 'class-validator';
 import { DeviceDescription, IDevice } from '../../../models';
 import { Trim } from '../../../transformers/string';
-import { DeviceTypeCode, FuelCode, OffTaker, OperatingConfiguration, PublicFundingType, RegistrationType, SourceAccessMode, SubsidyType, VolumeEvidenceType, YesNo } from '../../../utils/enums';
+import {
+  DeviceTypeCode,
+  FuelCode,
+  OffTaker,
+  OperatingConfiguration,
+  PublicFundingType,
+  RegistrationType,
+  SourceAccessMode,
+  SubsidyType,
+  VolumeEvidenceType,
+  YesNo,
+} from '../../../utils/enums';
 export class DeviceDTO implements IDevice {
   @ApiProperty()
   @IsNumber()

--- a/apps/drec-api/src/pods/device/dto/new-device.dto.ts
+++ b/apps/drec-api/src/pods/device/dto/new-device.dto.ts
@@ -6,12 +6,10 @@ import {
   IsDate,
   IsEnum,
   IsIn,
-  IsNotEmpty,
   IsNumber,
   IsOptional,
   IsString,
   Matches,
-  MaxDate,
   Min,
   ValidateIf,
 } from 'class-validator';
@@ -20,12 +18,26 @@ import { countryCodesList } from '../../../models/country-code';
 import { ConvertToNullIfEmpty, Trim } from '../../../transformers/string';
 import { UpperCase } from '../../../transformers/uppercase';
 import { DocumentType } from '../../document-uploads/entities/documents.entity';
-import { DeviceTypeCode, FuelCode, OffTaker, OperatingConfiguration, PublicFundingType, RegistrationType, SourceAccessMode, SubsidyType, VolumeEvidenceType, YesNo } from '../../../utils/enums';
+import {
+  DeviceTypeCode,
+  FuelCode,
+  OffTaker,
+  OperatingConfiguration,
+  PublicFundingType,
+  RegistrationType,
+  SourceAccessMode,
+  SubsidyType,
+  VolumeEvidenceType,
+  YesNo,
+} from '../../../utils/enums';
 
-export class NewDeviceDTO implements Omit<
-  IDevice,
-  'id' | 'status' | 'organizationId' | 'yieldValue' | 'labels' | 'groupId'
-> {
+export class NewDeviceDTO
+  implements
+    Omit<
+      IDevice,
+      'id' | 'status' | 'organizationId' | 'yieldValue' | 'labels' | 'groupId'
+    >
+{
   @ApiProperty()
   @Trim()
   @IsOptional()
@@ -80,8 +92,7 @@ export class NewDeviceDTO implements Omit<
   @IsOptional()
   @IsString()
   @Matches(/^-?\d{1,3}(\.\d+)?$/, {
-    message:
-      'Latitude should be a number from -90 to +90.',
+    message: 'Latitude should be a number from -90 to +90.',
   })
   latitude: string;
 
@@ -89,8 +100,7 @@ export class NewDeviceDTO implements Omit<
   @IsOptional()
   @IsString()
   @Matches(/^-?\d{1,3}(\.\d+)?$/, {
-    message:
-      'Longitude should be a number from -180 to +180.',
+    message: 'Longitude should be a number from -180 to +180.',
   })
   longitude: string;
 

--- a/apps/drec-api/src/pods/device/dto/update-device.dto.ts
+++ b/apps/drec-api/src/pods/device/dto/update-device.dto.ts
@@ -10,14 +10,24 @@ import {
   IsOptional,
   IsString,
   Matches,
-  MaxDate,
   Min,
 } from 'class-validator';
 import { DeviceDescription, IDevice } from '../../../models';
 import { countryCodesList } from '../../../models/country-code';
 import { Trim } from '../../../transformers/string';
 import { UpperCase } from '../../../transformers/uppercase';
-import { DeviceTypeCode, FuelCode, OffTaker, OperatingConfiguration, PublicFundingType, RegistrationType, SourceAccessMode, SubsidyType, VolumeEvidenceType, YesNo } from '../../../utils/enums';
+import {
+  DeviceTypeCode,
+  FuelCode,
+  OffTaker,
+  OperatingConfiguration,
+  PublicFundingType,
+  RegistrationType,
+  SourceAccessMode,
+  SubsidyType,
+  VolumeEvidenceType,
+  YesNo,
+} from '../../../utils/enums';
 export class UpdateDeviceDTO
   implements
     Omit<

--- a/apps/drec-api/src/pods/device/featured-sites.controller.ts
+++ b/apps/drec-api/src/pods/device/featured-sites.controller.ts
@@ -27,14 +27,16 @@ class FeaturedSitesIpRateLimitGuard implements CanActivate {
 
   canActivate(ctx: ExecutionContext): boolean {
     const req: any = ctx.switchToHttp().getRequest();
-    const ip: string =
-      req.ip || req.connection?.remoteAddress || 'unknown';
+    const ip: string = req.ip || req.connection?.remoteAddress || 'unknown';
     const now = Date.now();
     const recent = (this.hits.get(ip) || []).filter(
       (t: number) => now - t < this.windowMs,
     );
     if (recent.length >= this.max) {
-      throw new HttpException('Too many requests', HttpStatus.TOO_MANY_REQUESTS);
+      throw new HttpException(
+        'Too many requests',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
     }
     recent.push(now);
     this.hits.set(ip, recent);

--- a/apps/drec-api/src/pods/invitation/invitation.controller.ts
+++ b/apps/drec-api/src/pods/invitation/invitation.controller.ts
@@ -233,7 +233,10 @@ export class InvitationController {
     }
 
     try {
-      if (loggedUser.role === Role.Admin || loggedUser.role === Role.Registrant) {
+      if (
+        loggedUser.role === Role.Admin ||
+        loggedUser.role === Role.Registrant
+      ) {
         if (organizationId === null || organizationId === undefined) {
           throw new BadRequestException(
             responseFailure(

--- a/apps/drec-api/src/pods/org-api-licenses/api-key-resolver.service.ts
+++ b/apps/drec-api/src/pods/org-api-licenses/api-key-resolver.service.ts
@@ -8,9 +8,7 @@ const REVIEWER_ROLES: Role[] = [Role.Admin, Role.Reviewer, Role.SeniorReviewer];
 export class ApiKeyResolverService {
   private readonly logger = new Logger(ApiKeyResolverService.name);
 
-  constructor(
-    private readonly orgApiLicensesService: OrgApiLicensesService,
-  ) {}
+  constructor(private readonly orgApiLicensesService: OrgApiLicensesService) {}
 
   async resolveDeeplKey(user: {
     role: Role;
@@ -75,9 +73,11 @@ export class ApiKeyResolverService {
 
     // Org has their own key (and optionally their own workflow URL)
     if (license?.roboflowApiKey) {
-      const platformKeys = await this.orgApiLicensesService.findAdminOrgDecrypted();
+      const platformKeys =
+        await this.orgApiLicensesService.findAdminOrgDecrypted();
       return {
-        url: license.roboflowWorkflowUrl || platformKeys.roboflowWorkflowUrl || '',
+        url:
+          license.roboflowWorkflowUrl || platformKeys.roboflowWorkflowUrl || '',
         key: license.roboflowApiKey,
       };
     }
@@ -121,7 +121,10 @@ export class ApiKeyResolverService {
     return adminKeys.deeplApiKey;
   }
 
-  private async getPlatformRoboflowKey(): Promise<{ url: string; key: string }> {
+  private async getPlatformRoboflowKey(): Promise<{
+    url: string;
+    key: string;
+  }> {
     const adminKeys = await this.orgApiLicensesService.findAdminOrgDecrypted();
     if (!adminKeys.roboflowApiKey) {
       throw new ForbiddenException(

--- a/apps/drec-api/src/pods/org-api-licenses/org-api-licenses.controller.ts
+++ b/apps/drec-api/src/pods/org-api-licenses/org-api-licenses.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Logger,
-  Post,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Get, Logger, Post, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,

--- a/apps/drec-api/src/pods/org-api-licenses/org-api-licenses.service.ts
+++ b/apps/drec-api/src/pods/org-api-licenses/org-api-licenses.service.ts
@@ -79,9 +79,7 @@ export class OrgApiLicensesService {
     return this.repository.save(record);
   }
 
-  async findMasked(
-    organizationId: number,
-  ): Promise<{
+  async findMasked(organizationId: number): Promise<{
     roboflowApiKey: string | null;
     roboflowWorkflowUrl: string | null;
     deeplApiKey: string | null;
@@ -106,9 +104,7 @@ export class OrgApiLicensesService {
     };
   }
 
-  async findDecrypted(
-    organizationId: number,
-  ): Promise<{
+  async findDecrypted(organizationId: number): Promise<{
     roboflowApiKey: string | null;
     roboflowWorkflowUrl: string | null;
     deeplApiKey: string | null;
@@ -201,7 +197,11 @@ export class OrgApiLicensesService {
 
     if (!adminOrgId) {
       this.logger.warn('No Admin user found — platform API keys unavailable');
-      return { roboflowApiKey: null, roboflowWorkflowUrl: null, deeplApiKey: null };
+      return {
+        roboflowApiKey: null,
+        roboflowWorkflowUrl: null,
+        deeplApiKey: null,
+      };
     }
 
     const result = await this.findDecrypted(adminOrgId);

--- a/apps/drec-api/src/pods/permission/permission.service.ts
+++ b/apps/drec-api/src/pods/permission/permission.service.ts
@@ -78,8 +78,7 @@ export class PermissionService {
         permissionValue: permissionValue,
       });
       if (
-        (loggedInUser.role === Role.Registrant &&
-          data.entityType != 'Role') ||
+        (loggedInUser.role === Role.Registrant && data.entityType != 'Role') ||
         loggedInUser.role === Role.Admin ||
         loggedInUser.role === Role.Registrant
       ) {

--- a/apps/drec-api/src/pods/reads/reads.controller.ts
+++ b/apps/drec-api/src/pods/reads/reads.controller.ts
@@ -215,9 +215,7 @@ export class ReadsController {
         user.role === Role.Registrant &&
         user.organizationId != filter.organizationId
       ) {
-        this.logger.error(
-          `You cannot view the reads of another organization`,
-        );
+        this.logger.error(`You cannot view the reads of another organization`);
         throw new BadRequestException({
           success: false,
           message: `You cannot view the reads of another organization`,
@@ -228,9 +226,7 @@ export class ReadsController {
         user.role != Role.Admin &&
         user.api_user_id != organization.api_user_id
       ) {
-        this.logger.error(
-          `You cannot view the reads of another API user`,
-        );
+        this.logger.error(`You cannot view the reads of another API user`);
         throw new BadRequestException({
           success: false,
           message: `You cannot view the reads of another API user`,

--- a/apps/drec-api/src/pods/reads/reads.service.ts
+++ b/apps/drec-api/src/pods/reads/reads.service.ts
@@ -889,11 +889,10 @@ export class ReadsService {
     }
 
     // externalId → siteName (if uniquely scoped to org) → serialNumber (deprecated)
-    const device: DeviceDTO | null =
-      await this.deviceService.resolveDeviceKey(
-        deviceSerialNumber,
-        organizationId,
-      );
+    const device: DeviceDTO | null = await this.deviceService.resolveDeviceKey(
+      deviceSerialNumber,
+      organizationId,
+    );
     if (device === null) {
       this.logger.error(`Invalid device id`);
       throw new ConflictException({

--- a/apps/drec-api/src/pods/translate/translate.service.ts
+++ b/apps/drec-api/src/pods/translate/translate.service.ts
@@ -23,7 +23,9 @@ export class TranslateService {
     apiKey?: string,
   ): Promise<TranslateResult> {
     if (!apiKey) {
-      throw new BadRequestException('Translation is not configured — set the DeepL API key in Organization > Licenses');
+      throw new BadRequestException(
+        'Translation is not configured — set the DeepL API key in Organization > Licenses',
+      );
     }
 
     const host = apiKey.endsWith(':fx')

--- a/apps/drec-api/src/pods/upload-log/upload-log.service.ts
+++ b/apps/drec-api/src/pods/upload-log/upload-log.service.ts
@@ -90,9 +90,7 @@ export class UploadLogService {
         fileName: null,
         fileSizeBytes: null,
         fileHashSha256: null,
-        payloadHashSha256: createHash('sha256')
-          .update(canonical)
-          .digest('hex'),
+        payloadHashSha256: createHash('sha256').update(canonical).digest('hex'),
         ipAddress: params.ipAddress ?? null,
         userAgent: params.userAgent ?? null,
         metadata: params.metadata ?? null,

--- a/apps/drec-api/src/pods/user/user.controller.ts
+++ b/apps/drec-api/src/pods/user/user.controller.ts
@@ -466,7 +466,8 @@ export class UserController {
   @UseGuards(AuthGuard(['jwt', 'oauth2-client-password']))
   @ApiOperation({
     summary: 'Delete own account',
-    description: 'Permanently deletes the authenticated user account. Admin accounts cannot be deleted this way.',
+    description:
+      'Permanently deletes the authenticated user account. Admin accounts cannot be deleted this way.',
   })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/apps/drec-api/src/pods/user/user.service.ts
+++ b/apps/drec-api/src/pods/user/user.service.ts
@@ -202,8 +202,7 @@ export class UserService {
         data.api_user_id,
       );
       const isReviewer =
-        data.role === Role.Reviewer ||
-        data.role === Role.SeniorReviewer;
+        data.role === Role.Reviewer || data.role === Role.SeniorReviewer;
       let orgId;
       if (isReviewer) {
         // Reviewers join the admin's organization
@@ -255,8 +254,7 @@ export class UserService {
         where: { name: role },
       });
       const roleId = roleRecord?.id;
-      const reviewerWithInvite =
-        isReviewer && data.emailNotification;
+      const reviewerWithInvite = isReviewer && data.emailNotification;
 
       const user = await this.repository.save({
         firstName: data.firstName,
@@ -313,8 +311,10 @@ export class UserService {
   }
 
   public async checkForExistingUser(email: string): Promise<void> {
-    // Duplicate emails are permitted — different orgs/roles may share an email
-    return;
+    // Duplicate emails are permitted — different orgs/roles may share an email.
+    // Param retained because callers + tests pass it; this stub is a back-compat
+    // seam in case uniqueness rules return.
+    void email;
   }
 
   public async getAll(options?: FindManyOptions<User>): Promise<IUser[]> {
@@ -328,7 +328,9 @@ export class UserService {
     }
 
     if (user.role === Role.Registrant) {
-      const registrant = await this.getRegistrantPermissionStatus(user.api_user_id);
+      const registrant = await this.getRegistrantPermissionStatus(
+        user.api_user_id,
+      );
       user['permission_status'] = registrant.permission_status;
     }
     return user;
@@ -543,62 +545,162 @@ export class UserService {
     { module: string; perms: string; value: number }[]
   > = {
     Reviewer: [
-      { module: 'DEVICE_MANAGEMENT_CRUDL',         perms: 'Read',                     value: 1  },
-      { module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',  perms: 'Read,Write,Update',        value: 7  },
-      { module: 'USER_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update',        value: 7  },
-      { module: 'CHAT_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
+      { module: 'DEVICE_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      {
+        module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update',
+        value: 7,
+      },
+      { module: 'USER_MANAGEMENT_CRUDL', perms: 'Read,Write,Update', value: 7 },
+      {
+        module: 'CHAT_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
     ],
     SeniorReviewer: [
-      { module: 'DEVICE_MANAGEMENT_CRUDL',         perms: 'Read',                     value: 1  },
-      { module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',  perms: 'Read,Write,Update',        value: 7  },
-      { module: 'USER_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update',        value: 7  },
-      { module: 'CHAT_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
+      { module: 'DEVICE_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      {
+        module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update',
+        value: 7,
+      },
+      { module: 'USER_MANAGEMENT_CRUDL', perms: 'Read,Write,Update', value: 7 },
+      {
+        module: 'CHAT_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
     ],
     Registrant: [
-      { module: 'USER_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'ORGANIZATION_MANAGEMENT_CRUDL',    perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'FILE_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'DEVICE_MANAGEMENT_CRUDL',          perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read,Write',               value: 3  },
-      { module: 'DEVICE_BULK_MANAGEMENT_CRUDL',     perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'READS_MANAGEMENT_CRUDL',           perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read',                     value: 1  },
-      { module: 'INVITATION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'PASSWORD_MANAGEMENT_CRUDL',        perms: 'Write',                    value: 2  },
-      { module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',  perms: 'Read,Write',               value: 3  },
-      { module: 'SUBMISSION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'CHAT_MANAGEMENT_CRUDL',            perms: 'Read,Write',               value: 3  },
+      {
+        module: 'USER_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'ORGANIZATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'FILE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'DEVICE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',
+        perms: 'Read,Write',
+        value: 3,
+      },
+      {
+        module: 'DEVICE_BULK_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'READS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      {
+        module: 'INVITATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      { module: 'PASSWORD_MANAGEMENT_CRUDL', perms: 'Write', value: 2 },
+      {
+        module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write',
+        value: 3,
+      },
+      {
+        module: 'SUBMISSION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      { module: 'CHAT_MANAGEMENT_CRUDL', perms: 'Read,Write', value: 3 },
     ],
     Buyer: [
-      { module: 'USER_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update',        value: 7  },
-      { module: 'ORGANIZATION_MANAGEMENT_CRUDL',    perms: 'Read',                     value: 1  },
-      { module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read',                     value: 1  },
-      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read',                     value: 1  },
-      { module: 'INVITATION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'PASSWORD_MANAGEMENT_CRUDL',        perms: 'Write',                    value: 2  },
-      { module: 'CHAT_MANAGEMENT_CRUDL',            perms: 'Read,Write',               value: 3  },
+      { module: 'USER_MANAGEMENT_CRUDL', perms: 'Read,Write,Update', value: 7 },
+      { module: 'ORGANIZATION_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      { module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      {
+        module: 'INVITATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      { module: 'PASSWORD_MANAGEMENT_CRUDL', perms: 'Write', value: 2 },
+      { module: 'CHAT_MANAGEMENT_CRUDL', perms: 'Read,Write', value: 3 },
     ],
     SubBuyer: [
-      { module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read,Write',               value: 3  },
-      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read',                     value: 1  },
-      { module: 'INVITATION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'PASSWORD_MANAGEMENT_CRUDL',        perms: 'Write',                    value: 2  },
-      { module: 'CHAT_MANAGEMENT_CRUDL',            perms: 'Read,Write',               value: 3  },
+      {
+        module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',
+        perms: 'Read,Write',
+        value: 3,
+      },
+      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      {
+        module: 'INVITATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      { module: 'PASSWORD_MANAGEMENT_CRUDL', perms: 'Write', value: 2 },
+      { module: 'CHAT_MANAGEMENT_CRUDL', perms: 'Read,Write', value: 3 },
     ],
     SiteOperator: [
-      { module: 'USER_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update',        value: 7  },
-      { module: 'ORGANIZATION_MANAGEMENT_CRUDL',    perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'FILE_MANAGEMENT_CRUDL',            perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'DEVICE_MANAGEMENT_CRUDL',          perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL', perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'DEVICE_BULK_MANAGEMENT_CRUDL',     perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'READS_MANAGEMENT_CRUDL',           perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read',                     value: 1  },
-      { module: 'INVITATION_MANAGEMENT_CRUDL',      perms: 'Read,Write,Update,Delete', value: 15 },
-      { module: 'PASSWORD_MANAGEMENT_CRUDL',        perms: 'Write',                    value: 2  },
-      { module: 'SUBMISSION_MANAGEMENT_CRUDL',      perms: 'Read,Write',               value: 3  },
-      { module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',  perms: 'Read,Write,Update',        value: 7  },
-      { module: 'CHAT_MANAGEMENT_CRUDL',            perms: 'Read,Write',               value: 3  },
+      { module: 'USER_MANAGEMENT_CRUDL', perms: 'Read,Write,Update', value: 7 },
+      {
+        module: 'ORGANIZATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'FILE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'DEVICE_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'DEVICE_GROUPING_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'DEVICE_BULK_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      {
+        module: 'READS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      { module: 'CERTIFICATE_LOG_MANAGEMENT_CRUDL', perms: 'Read', value: 1 },
+      {
+        module: 'INVITATION_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update,Delete',
+        value: 15,
+      },
+      { module: 'PASSWORD_MANAGEMENT_CRUDL', perms: 'Write', value: 2 },
+      { module: 'SUBMISSION_MANAGEMENT_CRUDL', perms: 'Read,Write', value: 3 },
+      {
+        module: 'DEVICE_REVIEWS_MANAGEMENT_CRUDL',
+        perms: 'Read,Write,Update',
+        value: 7,
+      },
+      { module: 'CHAT_MANAGEMENT_CRUDL', perms: 'Read,Write', value: 3 },
     ],
   };
 
@@ -742,7 +844,8 @@ export class UserService {
       data.status === UserStatus.Active
     ) {
       const loginUrl =
-        this.configService.get<string>('UI_BASE_URL') || 'https://portal.drecs.org';
+        this.configService.get<string>('UI_BASE_URL') ||
+        'https://portal.drecs.org';
       this.mailService
         .send({
           to: updateUser.email,
@@ -753,7 +856,10 @@ export class UserService {
           }),
         })
         .catch((err) =>
-          this.logger.error(`Failed to send approval email to ${updateUser.email}`, err),
+          this.logger.error(
+            `Failed to send approval email to ${updateUser.email}`,
+            err,
+          ),
         );
     }
 
@@ -781,7 +887,9 @@ export class UserService {
       });
     }
     if (user.role === Role.Registrant) {
-      const registrant = await this.getRegistrantPermissionStatus(user.api_user_id);
+      const registrant = await this.getRegistrantPermissionStatus(
+        user.api_user_id,
+      );
       user['permission_status'] = registrant.permission_status;
     }
     return user;

--- a/apps/drec-api/src/utils/cross-source-verification.ts
+++ b/apps/drec-api/src/utils/cross-source-verification.ts
@@ -35,7 +35,11 @@ export interface CrossSourceResult {
 }
 
 export interface CrossSourceFlag {
-  type: 'overproduction' | 'underproduction' | 'inconsistent' | 'seasonal_anomaly';
+  type:
+    | 'overproduction'
+    | 'underproduction'
+    | 'inconsistent'
+    | 'seasonal_anomaly';
   severity: 'warning' | 'critical';
   description: string;
 }
@@ -63,8 +67,7 @@ export function computeCrossSourceVerification(
     sumModel += m.modelKwh;
   }
 
-  const performanceFactor =
-    sumModelSq > 0 ? sumModelActual / sumModelSq : 0;
+  const performanceFactor = sumModelSq > 0 ? sumModelActual / sumModelSq : 0;
   const simpleRatio = sumModel > 0 ? sumActual / sumModel : 0;
 
   // Compute ratios per month

--- a/apps/drec-api/src/utils/disputed-territories.ts
+++ b/apps/drec-api/src/utils/disputed-territories.ts
@@ -25,7 +25,12 @@ export interface DisputedTerritory {
 }
 
 /** Bounding box helper — produces a rectangle polygon. */
-function bbox(minLng: number, minLat: number, maxLng: number, maxLat: number): Array<[number, number]> {
+function bbox(
+  minLng: number,
+  minLat: number,
+  maxLng: number,
+  maxLat: number,
+): Array<[number, number]> {
   return [
     [minLng, minLat],
     [maxLng, minLat],
@@ -69,7 +74,7 @@ export const DISPUTED_TERRITORIES: DisputedTerritory[] = [
     id: 'gaza',
     name: 'Gaza Strip',
     claimants: ['ISR', 'PSE'],
-    polygon: bbox(34.22, 31.22, 34.58, 31.60),
+    polygon: bbox(34.22, 31.22, 34.58, 31.6),
   },
   {
     id: 'golan-heights',
@@ -105,31 +110,31 @@ export const DISPUTED_TERRITORIES: DisputedTerritory[] = [
     id: 'northern-cyprus',
     name: 'Northern Cyprus',
     claimants: ['CYP', 'TUR'],
-    polygon: bbox(32.26, 34.98, 34.60, 35.70),
+    polygon: bbox(32.26, 34.98, 34.6, 35.7),
   },
   {
     id: 'abkhazia',
     name: 'Abkhazia',
     claimants: ['GEO', 'RUS'],
-    polygon: bbox(40.00, 42.38, 42.30, 43.60),
+    polygon: bbox(40.0, 42.38, 42.3, 43.6),
   },
   {
     id: 'south-ossetia',
     name: 'South Ossetia',
     claimants: ['GEO', 'RUS'],
-    polygon: bbox(43.40, 42.20, 44.60, 42.80),
+    polygon: bbox(43.4, 42.2, 44.6, 42.8),
   },
   {
     id: 'transnistria',
     name: 'Transnistria (Pridnestrovie)',
     claimants: ['MDA', 'RUS'],
-    polygon: bbox(28.85, 46.15, 30.15, 48.50),
+    polygon: bbox(28.85, 46.15, 30.15, 48.5),
   },
   {
     id: 'nagorno-karabakh',
     name: 'Nagorno-Karabakh',
     claimants: ['ARM', 'AZE'],
-    polygon: bbox(45.90, 39.40, 47.20, 40.45),
+    polygon: bbox(45.9, 39.4, 47.2, 40.45),
   },
 ];
 
@@ -144,8 +149,7 @@ export function pointInPolygon(
     const [xi, yi] = polygon[i];
     const [xj, yj] = polygon[j];
     const intersects =
-      yi > lat !== yj > lat &&
-      lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi;
+      yi > lat !== yj > lat && lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi;
     if (intersects) inside = !inside;
   }
   return inside;

--- a/apps/drec-api/src/utils/evidence-pathway-classifier.ts
+++ b/apps/drec-api/src/utils/evidence-pathway-classifier.ts
@@ -1,5 +1,12 @@
-import { OperatingConfiguration, SourceAccessMode, EvidencePathway } from './enums';
-import { EvidenceRequirements, getEvidenceRequirements } from './evidence-requirements';
+import {
+  OperatingConfiguration,
+  SourceAccessMode,
+  EvidencePathway,
+} from './enums';
+import {
+  EvidenceRequirements,
+  getEvidenceRequirements,
+} from './evidence-requirements';
 import {
   ModeVerificationRule,
   getSourceAccessVerification,

--- a/apps/drec-api/src/utils/irradiance-estimate.ts
+++ b/apps/drec-api/src/utils/irradiance-estimate.ts
@@ -12,7 +12,7 @@
 interface IrradianceBand {
   maxAbsLat: number;
   yieldHigh: number; // optimistic (clear-sky, good tilt)
-  yieldLow: number;  // conservative (flat/suboptimal)
+  yieldLow: number; // conservative (flat/suboptimal)
 }
 
 /**


### PR DESCRIPTION
## Summary
Pre-existing CI **Code Quality** job has been red on every push to stage for a while. This makes it green again.

- 4 migrations: drop unused `queryRunner` param from no-op `down()` methods
- `certificate-log.controller`: drop unused `ConflictException` import
- `new-device.dto` / `update-device.dto`: drop unused `IsNotEmpty` / `MaxDate` imports
- `device.controller` line 690: split destructure so `role` can be `const`
- `device-group.service.processCsvFileAnotherLibrary` + caller: drop the unused `files` param (caller built the object only for that call — removed both)
- `user.service.checkForExistingUser`: `void`-cast the unused `email` param. Param kept because 4 callers + a spec assertion pass it; the stub is a back-compat seam in case uniqueness rules return.
- `pnpm prettier:fix` across `apps/drec-api` — 55 files reformatted, no logic changes.

## Test plan
- [x] `pnpm run lint:error` passes
- [x] `pnpm run prettier` passes
- [x] `pnpm exec tsc --noEmit` passes
- [ ] CI **Code Quality** job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)