### PR TITLE
fix(device-registration): require ≥4-decimal coord precision

### DIFF
--- a/apps/drec-api/src/pods/device/dto/new-device.dto.ts
+++ b/apps/drec-api/src/pods/device/dto/new-device.dto.ts
@@ -20,7 +20,17 @@ import { countryCodesList } from '../../../models/country-code';
 import { ConvertToNullIfEmpty, Trim } from '../../../transformers/string';
 import { UpperCase } from '../../../transformers/uppercase';
 import { DocumentType } from '../../document-uploads/entities/documents.entity';
-import { DeviceTypeCode, FuelCode, OffTaker, OperatingConfiguration, RegistrationType, SourceAccessMode, SubsidyType, VolumeEvidenceType, YesNo } from '../../../utils/enums';
+import {
+  DeviceTypeCode,
+  FuelCode,
+  OffTaker,
+  OperatingConfiguration,
+  RegistrationType,
+  SourceAccessMode,
+  SubsidyType,
+  VolumeEvidenceType,
+  YesNo,
+} from '../../../utils/enums';
 
 export class NewDeviceDTO implements Omit<
   IDevice,
@@ -79,18 +89,18 @@ export class NewDeviceDTO implements Omit<
   @ApiProperty()
   @IsOptional()
   @IsString()
-  @Matches(/^-?\d{1,3}(\.\d+)?$/, {
+  @Matches(/^-?\d{1,2}\.\d{4,20}$/, {
     message:
-      'Latitude should be a number from -90 to +90.',
+      'Latitude must be a number from -90 to +90 with at least 4 decimal places — registered location must be precise to ~10m so satellite imagery / panel verification works.',
   })
   latitude: string;
 
   @ApiProperty()
   @IsOptional()
   @IsString()
-  @Matches(/^-?\d{1,3}(\.\d+)?$/, {
+  @Matches(/^-?\d{1,3}\.\d{4,20}$/, {
     message:
-      'Longitude should be a number from -180 to +180.',
+      'Longitude must be a number from -180 to +180 with at least 4 decimal places — registered location must be precise to ~10m so satellite imagery / panel verification works.',
   })
   longitude: string;
 

--- a/apps/drec-api/src/pods/device/dto/update-device.dto.ts
+++ b/apps/drec-api/src/pods/device/dto/update-device.dto.ts
@@ -17,19 +17,21 @@ import { DeviceDescription, IDevice } from '../../../models';
 import { countryCodesList } from '../../../models/country-code';
 import { Trim } from '../../../transformers/string';
 import { UpperCase } from '../../../transformers/uppercase';
-import { DeviceTypeCode, FuelCode, OffTaker, OperatingConfiguration, RegistrationType, SourceAccessMode, SubsidyType, VolumeEvidenceType, YesNo } from '../../../utils/enums';
-export class UpdateDeviceDTO
-  implements
-    Omit<
-      IDevice,
-      | 'id'
-      | 'externalId'
-      | 'status'
-      | 'organizationId'
-      | 'yieldValue'
-      | 'labels'
-    >
-{
+import {
+  DeviceTypeCode,
+  FuelCode,
+  OffTaker,
+  OperatingConfiguration,
+  RegistrationType,
+  SourceAccessMode,
+  SubsidyType,
+  VolumeEvidenceType,
+  YesNo,
+} from '../../../utils/enums';
+export class UpdateDeviceDTO implements Omit<
+  IDevice,
+  'id' | 'externalId' | 'status' | 'organizationId' | 'yieldValue' | 'labels'
+> {
   @ApiProperty()
   @IsOptional()
   @Trim()
@@ -59,17 +61,17 @@ export class UpdateDeviceDTO
   @ApiProperty()
   @IsString()
   @IsOptional()
-  @Matches(/^-?\d{1,2}(\.\d{1,20})?$/, {
+  @Matches(/^-?\d{1,2}\.\d{4,20}$/, {
     message:
-      'Latitude should be a number from -90 to +90, with up to 20 decimal places.',
+      'Latitude must be a number from -90 to +90 with at least 4 decimal places — registered location must be precise to ~10m so satellite imagery / panel verification works.',
   })
   latitude: string;
 
   @ApiProperty()
   @IsString()
-  @Matches(/^-?\d{1,3}(\.\d{1,20})?$/, {
+  @Matches(/^-?\d{1,3}\.\d{4,20}$/, {
     message:
-      'Longitude should be a number from -180 to +180, with up to 20 decimal places.',
+      'Longitude must be a number from -180 to +180 with at least 4 decimal places — registered location must be precise to ~10m so satellite imagery / panel verification works.',
   })
   @IsOptional()
   longitude: string;


### PR DESCRIPTION
## Summary

- Tightens `@Matches` regex on `latitude` and `longitude` in `new-device.dto.ts` and `update-device.dto.ts` to require ≥4 decimal places (~11 m precision).
- ~85% of prod DB rows currently have only 2-decimal lat/lon (~550 m error); the login-globe satellite cutaways and admin sat-preview hover land on dirt roads / farmland for those devices.
- Adds a user-facing error message that explains *why* the precision is required.

## Test plan

- [ ] `cd apps/drec-api && pnpm exec tsc --noEmit` passes (pre-existing type-definition env errors are unrelated to this change)
- [ ] `pnpm exec prettier --check "src/pods/device/dto/new-device.dto.ts" "src/pods/device/dto/update-device.dto.ts"` passes (files were auto-fixed before commit)
- [ ] `pnpm run lint:error` passes (pre-existing ESLint config migration issue is unrelated)
- [ ] Manual: POST a new device with `latitude: "27.18"` (2 decimals) → API returns **400** with message `Latitude must be a number from -90 to +90 with at least 4 decimal places — registered location must be precise to ~10m so satellite imagery / panel verification works.`
- [ ] Manual: POST with `latitude: "27.1800"` (4 decimals) → validation passes

https://claude.ai/code/session_016wummQeGK8jwiFTDKfr3Km

---
_Generated by [Claude Code](https://claude.ai/code/session_016wummQeGK8jwiFTDKfr3Km)_