### PR TITLE
device-group: auto-release expired buyer reservations daily

### DIFF
--- a/apps/drec-api/src/pods/device-group/device-group.module.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.module.ts
@@ -18,6 +18,7 @@ import { Certificate } from '@energyweb/issuer-api';
 import { UserModule } from '../user/user.module';
 import { CertificateSettingEntity } from './certificate_setting.entity';
 import { DeviceBulkUploadProcessor } from './device-bulk-upload.processor';
+import { ReservationExpiryCron } from './reservation-expiry.cron';
 import { BullModule } from '@nestjs/bull';
 import { BulkUploadModule } from '../bulk-upload/bulk-upload.module';
 import { BulkUploadEntity } from '../bulk-upload/bulk-uploads.entity';
@@ -52,7 +53,7 @@ import { Queues } from '../../utils/enums/queues.enum';
     UserModule,
     forwardRef(() => BulkUploadModule),
   ],
-  providers: [DeviceGroupService, DeviceBulkUploadProcessor],
+  providers: [DeviceGroupService, DeviceBulkUploadProcessor, ReservationExpiryCron],
   exports: [DeviceGroupService, BullModule],
   controllers: [BuyerReservationController],
 })

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -1992,6 +1992,18 @@ export class DeviceGroupService {
     });
   }
 
+  async sweepExpiredReservations(): Promise<number> {
+    const activeGroups = await this.getAllReservationActive();
+    let released = 0;
+    for (const group of activeGroups) {
+      if (group.isExpired()) {
+        await this.deactivateReservation(group);
+        released++;
+      }
+    }
+    return released;
+  }
+
   async getCurrentInformationOfDevicesInReservation(
     groupId: string,
     pageNumber?: number,

--- a/apps/drec-api/src/pods/device-group/reservation-expiry.cron.ts
+++ b/apps/drec-api/src/pods/device-group/reservation-expiry.cron.ts
@@ -1,0 +1,22 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { NonConcurrentCron } from '../../lib/cron';
+import { CronExpression } from '@nestjs/schedule';
+import { DeviceGroupService } from './device-group.service';
+
+@Injectable()
+export class ReservationExpiryCron {
+  private readonly logger = new Logger(ReservationExpiryCron.name);
+
+  constructor(private readonly groupService: DeviceGroupService) {}
+
+  @NonConcurrentCron(CronExpression.EVERY_DAY_AT_1AM)
+  async handleExpiredReservations(): Promise<void> {
+    this.logger.log('Sweeping expired reservations…');
+    const released = await this.groupService.sweepExpiredReservations();
+    if (released > 0) {
+      this.logger.log(`Deactivated ${released} expired reservation(s) and released their devices`);
+    } else {
+      this.logger.debug('No expired reservations found');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a daily cron (1am UTC) that deactivates buyer reservations whose `reservationExpiryDate` has passed and clears their devices' `groupId` so they're available for new POs.
- Cherry-pick of the cron from develop (commit 8b92ec2e). Skips the surrounding siteName migration; pulls only the 3 minimal files this feature needs.
- All runtime dependencies (`isExpired`, `deactivateReservation`, `getAllReservationActive`, `findForGroup`, `removeFromGroup`) already exist on prod — change is additive.

## Why now
PowerTrust hit "already included in buyer reservation" on PO 99618 because devices 1944-1977 are stuck in group 153 (PO 40780), an old 2024 reservation whose expiry passed in June 2025. 16 other reservations on prod sit in the same stale state.

## Test plan
- [ ] After deploy, watch `drec-api` logs at 1am UTC for `ReservationExpiryCron` line.
- [ ] Verify the 16 still-zombie groups on prod get `reservationActive=false` and their devices' `groupId` cleared on the first run.
- [ ] Manually create a buyer reservation with a near-past `reservationExpiryDate`, wait for the next sweep, confirm it gets deactivated.

