### PR TITLE
prod: late-ongoing issuance — 10× concurrency with per-group jobId serialisation

### DIFF
--- a/apps/drec-api/src/pods/issuer/processors/late-ongoing-issuance.processor.ts
+++ b/apps/drec-api/src/pods/issuer/processors/late-ongoing-issuance.processor.ts
@@ -11,7 +11,12 @@ export class LateOngoingIssuanceProcessor {
     private readonly lateOngoingIssuanceService: LateOngoingIssuanceService,
   ) {}
 
-  @Process({ concurrency: 1 })
+  // Concurrency=10 with per-group jobId serialisation (see queue.add
+  // sites in late-ongoing-issuance.service.ts). Different groups
+  // process in parallel; same-group jobs are deduped/serialised by
+  // Bull so the inner group-state mutations in
+  // issuer.service.issueCertificate stay race-free.
+  @Process({ concurrency: 10 })
   async processLateOngoingIssuance(
     job: Job<{ groupId: number }>,
   ): Promise<void> {

--- a/apps/drec-api/src/pods/issuer/services/late-ongoing-issuance.service.ts
+++ b/apps/drec-api/src/pods/issuer/services/late-ongoing-issuance.service.ts
@@ -53,7 +53,15 @@ export class LateOngoingIssuanceService {
       }
 
       for (const group of activeDeviceGroups) {
-        await this.lateOngoingQueue.add({ groupId: group.id });
+        // jobId keys serialisation per group: Bull won't run two jobs
+        // with the same jobId in parallel, and won't add a duplicate
+        // when one is already pending. Pair with the bumped concurrency
+        // on the processor — different groups run in parallel, same
+        // group queues at most once.
+        await this.lateOngoingQueue.add(
+          { groupId: group.id },
+          { jobId: `late-${group.id}` },
+        );
       }
 
       this.logger.debug(
@@ -74,10 +82,13 @@ export class LateOngoingIssuanceService {
     // If no group ID provided, schedule issuance for all active groups
     if (!groupId) return this.scheduleIssuance();
 
-    // Add a job for the specified group ID
+    // Add a job for the specified group ID.
+    // Same jobId scheme as scheduleIssuance — Bull serialises same-
+    // group jobs and skips adding a duplicate while one is in flight.
     await this.lateOngoingQueue.add(
       { groupId: groupId },
       {
+        jobId: `late-${groupId}`,
         lifo: true,
       },
     );


### PR DESCRIPTION
## Summary

Cherry-pick of `c54768e4` from develop. Bumps `LateOngoingIssuanceProcessor` concurrency from 1 → 10 and adds per-group `jobId` serialisation to both `lateOngoingQueue.add` sites so different groups process in parallel while same-group jobs stay serialised (and deduplicated while one is in flight).

## Why now

PowerTrust (org 32) is the entire late-ongoing queue — 96% of all cycles ever, 89% of currently-pending. With single-threaded processing and 265k+ pending PT cycles, fresh submissions sit behind the backlog for days. PT has an external deadline of May 18 for 139 sites.

## Correctness invariant

`issuer.service.issueCertificate` mutates per-group state (`targetVolumeCertificateGenerationRequested...`, `leftOverReadsByCountryCode`, the auto-end-reservation threshold check). Two jobs for the **same** group must not run concurrently. Bull's `jobId` provides exactly that guarantee — same `jobId` = serialised, and a second `add` while the first is in flight is dropped as a duplicate. Different groups are independent.

`certificateService.issue` is upstream off-chain — nonce-managed on-chain work runs in a separate downstream queue, so this change does NOT multiply pressure on the issuer wallet.

## Stage verification

- Two parallel triggers (groups 118 + 133) ran at the same timestamp — parallel processing confirmed.
- Same group fired twice within 0.3s produced exactly one job — jobId dedup confirmed.
- API starts clean on stage, no new errors from the change.

## Test plan

- [ ] Watch prod mint rate in the first hour post-deploy (expect roughly 10× lift for active groups).
- [ ] Verify `device_lateongoing_certificate_cycle` `certificate_issued = true` rows climbing faster than under concurrency=1.
- [ ] Roll back if anything misbehaves: `git revert 1553a051` PR, or push the prior prod tip back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)