### PR TITLE
prod REVERT: late-ongoing concurrency=10 starves DB connection pool

### DIFF
--- a/apps/drec-api/src/pods/issuer/processors/late-ongoing-issuance.processor.ts
+++ b/apps/drec-api/src/pods/issuer/processors/late-ongoing-issuance.processor.ts
@@ -11,12 +11,7 @@ export class LateOngoingIssuanceProcessor {
     private readonly lateOngoingIssuanceService: LateOngoingIssuanceService,
   ) {}
 
-  // Concurrency=10 with per-group jobId serialisation (see queue.add
-  // sites in late-ongoing-issuance.service.ts). Different groups
-  // process in parallel; same-group jobs are deduped/serialised by
-  // Bull so the inner group-state mutations in
-  // issuer.service.issueCertificate stay race-free.
-  @Process({ concurrency: 10 })
+  @Process({ concurrency: 1 })
   async processLateOngoingIssuance(
     job: Job<{ groupId: number }>,
   ): Promise<void> {

--- a/apps/drec-api/src/pods/issuer/services/late-ongoing-issuance.service.ts
+++ b/apps/drec-api/src/pods/issuer/services/late-ongoing-issuance.service.ts
@@ -53,15 +53,7 @@ export class LateOngoingIssuanceService {
       }
 
       for (const group of activeDeviceGroups) {
-        // jobId keys serialisation per group: Bull won't run two jobs
-        // with the same jobId in parallel, and won't add a duplicate
-        // when one is already pending. Pair with the bumped concurrency
-        // on the processor — different groups run in parallel, same
-        // group queues at most once.
-        await this.lateOngoingQueue.add(
-          { groupId: group.id },
-          { jobId: `late-${group.id}` },
-        );
+        await this.lateOngoingQueue.add({ groupId: group.id });
       }
 
       this.logger.debug(
@@ -82,13 +74,10 @@ export class LateOngoingIssuanceService {
     // If no group ID provided, schedule issuance for all active groups
     if (!groupId) return this.scheduleIssuance();
 
-    // Add a job for the specified group ID.
-    // Same jobId scheme as scheduleIssuance — Bull serialises same-
-    // group jobs and skips adding a duplicate while one is in flight.
+    // Add a job for the specified group ID
     await this.lateOngoingQueue.add(
       { groupId: groupId },
       {
-        jobId: `late-${groupId}`,
         lifo: true,
       },
     );


### PR DESCRIPTION
## URGENT — revert PR #776 before next 8-hour cron tick at 16:00 UTC

The concurrency=10 + jobId change shipped in PR #776 / commit \`1553a051\` starves TypeORM's default 10-connection pool: each Bull worker holds a transaction open per cycle, so 10 concurrent workers consume the entire pool and normal API requests (login, /device/my, etc.) time out at 504 with the upstream gateway.

## How discovered

Manifested on stage when registrant flow was tested ~30 min after stage promote. \`pg_stat_activity\` on stage:

\`\`\`
state                | count
---------------------+-------
idle in transaction  | 10
idle                 | 2
active               | 1
\`\`\`

10 idle-in-transaction = the 10 concurrency. Login API call hung 60s and returned 504 because no connection was free.

## Why prod hasn't bitten yet

Late-ongoing cron is \`EVERY_8_HOURS\`. Last natural fire was 08:00 UTC; next is **16:00 UTC** (~5h from this PR's open time). When that fires it'll queue all active groups (~88 PT groups) and the symptom will replicate on prod immediately. Currently 0 idle-in-transaction on prod, so this revert lands ahead of the bomb.

## Real fix later

Bump TypeORM's connection pool size (\`extra: { max: 30 }\` or similar) so concurrency=10 + headroom for normal API traffic both fit. Then re-ship the concurrency change. Stage already rolled back to validate that path.

## Test plan

- [ ] Merge before 16:00 UTC.
- [ ] Confirm next cron tick shows the old single-threaded \`Group:: N\` log pattern.
- [ ] No connection-pool exhaustion in \`pg_stat_activity\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)