### PR TITLE
issuer: refuse mint when fromTime precedes reservationStart or toTime <= fromTime

### DIFF
--- a/apps/drec-api/src/pods/issuer/services/certificate.service.ts
+++ b/apps/drec-api/src/pods/issuer/services/certificate.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 
 import {
   IGetAllCertificatesOptions,
@@ -57,6 +57,30 @@ export class CertificateService {
     toTime: Date,
     certificateTransactionUID: string,
   ): IIssueCommandParams<ICertificateMetadata> {
+    // Guard against the 2026-05-17 incident: 4 certs were minted for PO 69115
+    // with fromTime ~5 months before reservation start. Reject any mint where
+    // fromTime precedes the reservation window or the window is inverted, so
+    // garbage timestamps surface as an error here instead of on chain.
+    const reservationStart = group.reservationStartDate
+      ? new Date(group.reservationStartDate)
+      : null;
+    if (reservationStart && fromTime.getTime() < reservationStart.getTime()) {
+      const msg =
+        `Refusing to issue certificate for group ${group.id} (${group.name}): ` +
+        `fromTime ${fromTime.toISOString()} is before reservationStartDate ${reservationStart.toISOString()}. ` +
+        `certificateTransactionUID=${certificateTransactionUID}`;
+      this.logger.error(msg);
+      throw new BadRequestException(msg);
+    }
+    if (toTime.getTime() <= fromTime.getTime()) {
+      const msg =
+        `Refusing to issue certificate for group ${group.id} (${group.name}): ` +
+        `toTime ${toTime.toISOString()} is not after fromTime ${fromTime.toISOString()}. ` +
+        `certificateTransactionUID=${certificateTransactionUID}`;
+      this.logger.error(msg);
+      throw new BadRequestException(msg);
+    }
+
     const address = group.buyerAddress || process.env.DREC_BLOCKCHAIN_ADDRESS;
     return {
       deviceId: group.id?.toString(),


### PR DESCRIPTION
## Summary

Cherry-pick of `ae153485` from develop.

Adds a precondition in `CertificateService.getIssuanceParams` that rejects any cert mint where:
- `fromTime < group.reservationStartDate`, or
- `toTime <= fromTime`

Both raise `BadRequestException` and log the offending `(group, fromTime, toTime, certificateTransactionUID)` tuple.

## Why

On 2026-05-17 07:50:54-56 UTC, 4 certs (243112-243115) were minted for PO 69115 sites Bhadhaura / Jangipur / Jahagirganj / Kaptanganj with `fromTime = 2024-12-31 00:00:01 UTC` — ~5 months before the reservation start (`2024-12-31 18:30:00 UTC`) and covering a 5-month window instead of just May 2025. PowerTrust flagged the bad tokens to Paul → email thread on 2026-05-26.

Root cause is not yet pinned. Log retention is < 9 days so the in-app evidence from May 17 is gone, and static-tracing through `issuer.service.ts:251 calculateDateRanges` doesn't reproduce the symptom from the data currently in the DB. The other ~41 sites in the same PO got correct certs an hour earlier on the same day, so it's a localised, hard-to-repro path.

This patch turns any future recurrence into an error at the boundary instead of letting it reach chain. Doesn't fix the root cause; just bounds the blast radius until the root cause is found.

## Notes

- Conflict on cherry-pick was auto-resolved (`devicegroup_uid` on prod vs `deviceGroupUid` on develop — the metadata-field rename never made it here yet).
- Already on develop (`ae153485`) and stage as of 2026-05-26.
- Corrective certs for the 4 bad mints are tracked separately (runbook at `/tmp/correct-po69115-may-certs.md` on Peter's machine); this PR is just the guard.

## Test plan

- [ ] CI passes on this branch.
- [ ] After merge + deploy, manually verify mint still works for any in-flight PT issuance (e.g. a freshly-minted PO 69115 monthly cert).
- [ ] Monitor `drec-api` logs for `Refusing to issue certificate` lines — any hit is real signal worth digging into.