### PR TITLE
fix(reservation): release devices from expired groups even after deactivation

### DIFF
--- a/apps/drec-api/src/pods/device-group/device-group.service.spec.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.spec.ts
@@ -748,4 +748,78 @@ describe('DeviceGroupService', () => {
       expect(result).toBe(5);
     });
   });
+
+  describe('sweepExpiredReservations', () => {
+    it('releases devices from an expired reservation even when reservationActive is already false', async () => {
+      // endReservation() flips reservationActive to false at reservationEndDate,
+      // before reservationExpiryDate. The sweep must still release this group.
+      const endedExpiredGroup = {
+        id: 156,
+        reservationActive: false,
+        reservationExpiryDate: new Date('2025-06-30T23:59:59Z'),
+      } as unknown as DeviceGroup;
+
+      jest
+        .spyOn(service, 'getExpiredReservationsWithLinkedDevices')
+        .mockResolvedValue([endedExpiredGroup]);
+      const saveSpy = jest
+        .spyOn(repository, 'save')
+        .mockResolvedValue(endedExpiredGroup as any);
+      (deviceService.findForGroup as jest.Mock).mockResolvedValue([
+        { id: 2001 },
+        { id: 2002 },
+      ]);
+      const removeSpy = deviceService.removeFromGroup as jest.Mock;
+      removeSpy.mockClear();
+
+      const released = await service.sweepExpiredReservations();
+
+      expect(released).toBe(1);
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ reservationActive: false }),
+      );
+      expect(removeSpy).toHaveBeenCalledTimes(2);
+      expect(removeSpy).toHaveBeenCalledWith(2001, 156);
+      expect(removeSpy).toHaveBeenCalledWith(2002, 156);
+    });
+  });
+
+  describe('getExpiredReservationsWithLinkedDevices', () => {
+    it('filters on expiry + EXISTS-devices and never filters on reservationActive', async () => {
+      const groups = [{ id: 156 }] as DeviceGroup[];
+      const subQuery = {
+        select: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getQuery: jest.fn().mockReturnValue('SUBQ'),
+      };
+      const qb: any = {
+        where: jest.fn().mockReturnThis(),
+        subQuery: jest.fn().mockReturnValue(subQuery),
+        getMany: jest.fn().mockResolvedValue(groups),
+      };
+      // andWhere may receive a raw string or a subquery-building callback;
+      // invoke the callback so the EXISTS clause is exercised.
+      qb.andWhere = jest.fn().mockImplementation((arg: any) => {
+        if (typeof arg === 'function') arg(qb);
+        return qb;
+      });
+      jest.spyOn(repository, 'createQueryBuilder').mockReturnValue(qb);
+
+      const result = await service.getExpiredReservationsWithLinkedDevices();
+
+      expect(result).toBe(groups);
+      expect(qb.where).toHaveBeenCalledWith(
+        'group.reservationExpiryDate IS NOT NULL',
+      );
+      const clauseStrings = [
+        ...qb.where.mock.calls.flat(),
+        ...qb.andWhere.mock.calls.flat(),
+      ].filter((a) => typeof a === 'string');
+      expect(
+        clauseStrings.some((s: string) => s.includes('reservationActive')),
+      ).toBe(false);
+      expect(qb.getMany).toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -2335,15 +2335,56 @@ export class DeviceGroupService {
   }
 
   async sweepExpiredReservations(): Promise<number> {
-    const activeGroups = await this.getAllReservationActive();
+    // Release devices from every reservation that is past its expiry date and
+    // still holds devices — regardless of reservationActive. Previously this
+    // iterated getAllReservationActive() (reservationActive = true) and skipped
+    // groups whose flag had already been flipped to false by endReservation(),
+    // which runs at reservationEndDate, ahead of reservationExpiryDate. Those
+    // ended-but-unexpired groups therefore never reached deactivateReservation()
+    // and their devices stayed locked to a dead reservation forever — blocking
+    // them from being added to the next PO (createOne only accepts groupId ==
+    // null). See getExpiredReservationsWithLinkedDevices().
+    const expiredGroups = await this.getExpiredReservationsWithLinkedDevices();
     let released = 0;
-    for (const group of activeGroups) {
-      if (group.isExpired()) {
-        await this.deactivateReservation(group);
-        released++;
-      }
+    for (const group of expiredGroups) {
+      await this.deactivateReservation(group);
+      released++;
     }
     return released;
+  }
+
+  /**
+   * Reservations past their expiry date that still have devices linked
+   * (device.groupId = group.id), independent of reservationActive.
+   *
+   * The release sweep must not key off reservationActive: endReservation() sets
+   * that flag to false at reservationEndDate — well before reservationExpiryDate
+   * — to stop scheduling new issuance cycles while intentionally keeping devices
+   * linked for the tail window. By the time a group is due for device release at
+   * expiry it is therefore already inactive, so getAllReservationActive() never
+   * returned it. Keying the sweep here off expiry + an EXISTS-devices guard fixes
+   * that and is self-healing for groups already stranded (PO 69115b et al.,
+   * June 2026).
+   *
+   * The EXISTS guard also keeps the sweep cheap and idempotent: once a group's
+   * devices are released it drops out of the result set rather than being
+   * reprocessed on every nightly run.
+   */
+  async getExpiredReservationsWithLinkedDevices(): Promise<DeviceGroup[]> {
+    return this.repository
+      .createQueryBuilder('group')
+      .where('group.reservationExpiryDate IS NOT NULL')
+      .andWhere('group.reservationExpiryDate <= :now', { now: new Date() })
+      .andWhere((qb) => {
+        const sub = qb
+          .subQuery()
+          .select('1')
+          .from(Device, 'd')
+          .where('d.groupId = group.id')
+          .getQuery();
+        return `EXISTS ${sub}`;
+      })
+      .getMany();
   }
 
   public async getDeviceGrouplog(


### PR DESCRIPTION
## Problem

The nightly `ReservationExpiryCron` → `sweepExpiredReservations()` is the only path that unlinks devices from a finished reservation (`deactivateReservation` → `removeFromGroup`, sets `device.groupId = null`). It iterated `getAllReservationActive()` (`where reservationActive: true`) and released the expired ones.

But `endReservation()` sets `reservationActive = false` at **`reservationEndDate`** — deliberately ahead of `reservationExpiryDate`, so it can stop scheduling issuance cycles while keeping devices linked for the tail-read window (the May-2026 fix). The consequence: by the time a group is actually due for device release (at expiry), it is **already inactive**, so the sweep never sees it. `deactivateReservation()` never runs and the devices stay locked to a dead reservation forever.

Because `createOne()` only accepts devices with `groupId == null` (`device-group.service.ts:951`), those stranded devices can never join the next PO's reservation — so **every rollover orphans the prior cohort**.

## Production impact (PO 69115b)

- Group **156** (PO 88079): `reservationActive=false`, expired **2025-06-30**, yet still holds **129 devices** (124 with full CY2025 `Delta` reads).
- The 69115b reservation (group **217**, active 2025) could only grab the free devices → just **Ghugali-2** → exactly **1 of ~137 sites** producing certificates. The other 136 sites' generation is complete but uncertifiable.

## Fix

Key the sweep off a new `getExpiredReservationsWithLinkedDevices()` — `reservationExpiryDate <= now` **AND** `EXISTS (device WHERE groupId = group.id)`, **independent of `reservationActive`**. The `EXISTS` guard keeps it cheap/idempotent (released groups drop out of the result set) and makes it **self-healing** for already-stranded groups.

## Tests

`device-group.service.spec.ts` (22 pass): release fires for an expired group with `reservationActive=false`; the query filters on expiry+EXISTS and never references `reservationActive`.

## Rollout notes / call for review

- **First run after deploy will release devices from _all_ historical expired-but-still-linked groups platform-wide**, not just PowerTrust's. That is the intended end-state (those devices _should_ be free) and is non-destructive — no reads/certs touched, only `device.groupId` cleared — but it is a broad one-time sweep. Worth running intentionally and watching the `Released N device(s) from expired group X` logs. Can gate the first pass behind a dry-run/log-only flag if preferred.
- This **unblocks the PowerTrust data remediation**: once group 156's devices are released (`groupId=null`), they become eligible to attach to group 217 and re-run CY2025 issuance.
- **Out of scope (flagged, not changed):** `device-group.entity.ts` declares `reservationExpiryDate` as `@CreateDateColumn` — semantically wrong for an expiry field. Prod rows hold correct overridden values, so it is harmless today, but it is a latent trap worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)