### PR TITLE
fix(reservation): release devices from expired groups on prod's sweep path

### DIFF
--- a/apps/drec-api/src/pods/device-group/device-group.service.spec.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.spec.ts
@@ -89,6 +89,7 @@ describe('DeviceGroupService', () => {
           provide: DeviceService,
           useValue: {
             findForGroup: jest.fn().mockResolvedValue([{ id: 1 }, { id: 2 }]),
+            removeFromGroup: jest.fn().mockResolvedValue({}),
           } as any,
         },
         {
@@ -711,6 +712,91 @@ describe('DeviceGroupService', () => {
         'US',
       );
       expect(result).toBe(5);
+    });
+  });
+
+  describe('deactivateReservation', () => {
+    it('unlinks the group devices, not just flips reservationActive', async () => {
+      const group = { id: 156, reservationActive: true } as unknown as DeviceGroup;
+      jest.spyOn(repository, 'save').mockResolvedValue(group as any);
+      (deviceService.findForGroup as jest.Mock).mockResolvedValue([
+        { id: 2001 },
+        { id: 2002 },
+      ]);
+      const removeSpy = deviceService.removeFromGroup as jest.Mock;
+      removeSpy.mockClear();
+
+      await service.deactivateReservation(group);
+
+      expect(group.reservationActive).toBe(false);
+      expect(removeSpy).toHaveBeenCalledTimes(2);
+      expect(removeSpy).toHaveBeenCalledWith(2001, 156);
+      expect(removeSpy).toHaveBeenCalledWith(2002, 156);
+    });
+  });
+
+  describe('sweepExpiredReservations', () => {
+    it('releases devices from an expired reservation even when reservationActive is already false', async () => {
+      const endedExpiredGroup = {
+        id: 156,
+        reservationActive: false,
+        reservationExpiryDate: new Date('2025-06-30T23:59:59Z'),
+      } as unknown as DeviceGroup;
+
+      jest
+        .spyOn(service, 'getExpiredReservationsWithLinkedDevices')
+        .mockResolvedValue([endedExpiredGroup]);
+      jest.spyOn(repository, 'save').mockResolvedValue(endedExpiredGroup as any);
+      (deviceService.findForGroup as jest.Mock).mockResolvedValue([
+        { id: 2001 },
+        { id: 2002 },
+      ]);
+      const removeSpy = deviceService.removeFromGroup as jest.Mock;
+      removeSpy.mockClear();
+
+      const released = await service.sweepExpiredReservations();
+
+      expect(released).toBe(1);
+      expect(removeSpy).toHaveBeenCalledTimes(2);
+      expect(removeSpy).toHaveBeenCalledWith(2001, 156);
+      expect(removeSpy).toHaveBeenCalledWith(2002, 156);
+    });
+  });
+
+  describe('getExpiredReservationsWithLinkedDevices', () => {
+    it('filters on expiry + EXISTS-devices and never filters on reservationActive', async () => {
+      const groups = [{ id: 156 }] as DeviceGroup[];
+      const subQuery = {
+        select: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getQuery: jest.fn().mockReturnValue('SUBQ'),
+      };
+      const qb: any = {
+        where: jest.fn().mockReturnThis(),
+        subQuery: jest.fn().mockReturnValue(subQuery),
+        getMany: jest.fn().mockResolvedValue(groups),
+      };
+      qb.andWhere = jest.fn().mockImplementation((arg: any) => {
+        if (typeof arg === 'function') arg(qb);
+        return qb;
+      });
+      jest.spyOn(repository, 'createQueryBuilder').mockReturnValue(qb);
+
+      const result = await service.getExpiredReservationsWithLinkedDevices();
+
+      expect(result).toBe(groups);
+      expect(qb.where).toHaveBeenCalledWith(
+        'group.reservationExpiryDate IS NOT NULL',
+      );
+      const clauseStrings = [
+        ...qb.where.mock.calls.flat(),
+        ...qb.andWhere.mock.calls.flat(),
+      ].filter((a) => typeof a === 'string');
+      expect(
+        clauseStrings.some((s: string) => s.includes('reservationActive')),
+      ).toBe(false);
+      expect(qb.getMany).toHaveBeenCalled();
     });
   });
 });

--- a/apps/drec-api/src/pods/device-group/device-group.service.spec.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.spec.ts
@@ -717,7 +717,10 @@ describe('DeviceGroupService', () => {
 
   describe('deactivateReservation', () => {
     it('unlinks the group devices, not just flips reservationActive', async () => {
-      const group = { id: 156, reservationActive: true } as unknown as DeviceGroup;
+      const group = {
+        id: 156,
+        reservationActive: true,
+      } as unknown as DeviceGroup;
       jest.spyOn(repository, 'save').mockResolvedValue(group as any);
       (deviceService.findForGroup as jest.Mock).mockResolvedValue([
         { id: 2001 },
@@ -746,7 +749,9 @@ describe('DeviceGroupService', () => {
       jest
         .spyOn(service, 'getExpiredReservationsWithLinkedDevices')
         .mockResolvedValue([endedExpiredGroup]);
-      jest.spyOn(repository, 'save').mockResolvedValue(endedExpiredGroup as any);
+      jest
+        .spyOn(repository, 'save')
+        .mockResolvedValue(endedExpiredGroup as any);
       (deviceService.findForGroup as jest.Mock).mockResolvedValue([
         { id: 2001 },
         { id: 2002 },

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -1889,6 +1889,25 @@ export class DeviceGroupService {
     if (group) {
       group.reservationActive = false;
       await this.repository.save(group);
+
+      // Release the group's devices so they can be added to a new reservation.
+      // Previously this only flipped reservationActive and returned, so devices
+      // swept here stayed linked to a dead reservation forever — and createOne()
+      // only accepts devices with groupId == null, so they could never be added
+      // to the next PO. Device-unlink at end-of-life used to rely solely on
+      // endReservation(), but the sweep deactivates expired groups before
+      // endReservation() runs, leaving them stranded (PO 69115b et al.).
+      const devices = await this.deviceService.findForGroup(group.id);
+      if (devices?.length) {
+        await Promise.all(
+          devices.map((device: Device) =>
+            this.deviceService.removeFromGroup(device.id, group.id),
+          ),
+        );
+        this.logger.log(
+          `Released ${devices.length} device(s) from expired group ${group.id}`,
+        );
+      }
       return;
     }
   }
@@ -1993,15 +2012,54 @@ export class DeviceGroupService {
   }
 
   async sweepExpiredReservations(): Promise<number> {
-    const activeGroups = await this.getAllReservationActive();
+    // Release devices from every reservation that is past its expiry date and
+    // still holds devices — regardless of reservationActive. Previously this
+    // iterated getAllReservationActive() (reservationActive = true) and skipped
+    // groups whose flag had already been flipped to false (by endReservation or
+    // a prior sweep pass), so those ended-but-still-linked groups never reached
+    // deactivateReservation() and their devices stayed locked to a dead
+    // reservation forever — blocking them from being added to the next PO
+    // (createOne only accepts groupId == null). See
+    // getExpiredReservationsWithLinkedDevices().
+    const expiredGroups = await this.getExpiredReservationsWithLinkedDevices();
     let released = 0;
-    for (const group of activeGroups) {
-      if (group.isExpired()) {
-        await this.deactivateReservation(group);
-        released++;
-      }
+    for (const group of expiredGroups) {
+      await this.deactivateReservation(group);
+      released++;
     }
     return released;
+  }
+
+  /**
+   * Reservations past their expiry date that still have devices linked
+   * (device.groupId = group.id), independent of reservationActive.
+   *
+   * The release sweep must not key off reservationActive: an expired group is
+   * routinely already inactive by the time its devices are due for release
+   * (endReservation flips the flag at reservationEndDate, and the sweep itself
+   * deactivates on its first pass), so getAllReservationActive() never returned
+   * it. Keying off expiry + an EXISTS-devices guard fixes that and is
+   * self-healing for groups already stranded (PO 69115b et al.).
+   *
+   * The EXISTS guard also keeps the sweep cheap and idempotent: once a group's
+   * devices are released it drops out of the result set rather than being
+   * reprocessed on every nightly run.
+   */
+  async getExpiredReservationsWithLinkedDevices(): Promise<DeviceGroup[]> {
+    return this.repository
+      .createQueryBuilder('group')
+      .where('group.reservationExpiryDate IS NOT NULL')
+      .andWhere('group.reservationExpiryDate <= :now', { now: new Date() })
+      .andWhere((qb) => {
+        const sub = qb
+          .subQuery()
+          .select('1')
+          .from(Device, 'd')
+          .where('d.groupId = group.id')
+          .getQuery();
+        return `EXISTS ${sub}`;
+      })
+      .getMany();
   }
 
   async getCurrentInformationOfDevicesInReservation(


### PR DESCRIPTION
Prod-targeted port of #782 (which targets `develop`). **Base is `prod`** — prod is 511 commits behind develop and has diverged, so #782 cannot be deployed by pushing develop→prod, and #782 cherry-picked alone would be **inert on prod** (see below). This branches from `origin/prod` and fixes prod's actual code.

## Why #782 doesn't work on prod

Prod (`170d99a5`, #775) has a *different* shape of the bug:

1. **`deactivateReservation()` never unlinked devices** — it only flipped `reservationActive` and returned. On develop that method already unlinks; that change is one of the 511 commits not on prod. The sweep calls `deactivateReservation()` on expired groups, so on prod they get deactivated but their devices stay linked forever.
2. **`sweepExpiredReservations()` iterated `getAllReservationActive()`** (`reservationActive = true`), so a group already deactivated — by `endReservation()` at `reservationEndDate`, or by the sweep's own earlier pass — was invisible and never reprocessed.

Together: an expired reservation gets deactivated, its devices are never released, and because `createOne()` only accepts devices with `groupId == null`, they can never join the next PO. Each rollover strands the prior cohort.

## Production impact (PO 69115b)

Group **156** (PO 88079): `reservationActive=false`, expired **2025-06-30**, still holds **129 devices** (124 with full CY2025 `Delta` reads). The 69115b reservation (group **217**) could only grab the free device → **1 of ~137 sites** tokenizing.

## Fix

1. Restore the `removeFromGroup` loop in `deactivateReservation()` (aligns prod with develop).
2. Key the sweep off new `getExpiredReservationsWithLinkedDevices()` — `reservationExpiryDate <= now` AND `EXISTS (device WHERE groupId = group.id)`, independent of `reservationActive`. EXISTS guard keeps it cheap/idempotent and self-healing.

## Tests

Added to `device-group.service.spec.ts`: `deactivateReservation` unlinks devices; sweep releases an expired group with `reservationActive=false`; the query filters on expiry+EXISTS and never references `reservationActive`. (Note: local `jest` run on this branch is blocked by a pre-existing `FindConditions` import vs. installed typeorm — a dev-env dependency mismatch, not introduced here; CI builds prod with prod's own deps.)

## Rollout notes

- **First nightly sweep after deploy releases devices from _all_ historical expired-still-linked groups platform-wide**, not just PowerTrust's. Intended end-state and non-destructive (only clears `device.groupId`; no reads/certs touched), but it's a broad one-time sweep — deploy intentionally and watch the `Released N device(s) from expired group X` logs.
- **Unblocks the PowerTrust data remediation**: once group 156's devices are released (`groupId=null`), they can be re-attached to group 217 and CY2025 issuance re-run. (The data remediation is being scoped separately and is not part of this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)