### PR TITLE
fix(issuer): mark reads certified only after the mint succeeds (prevent phantom-certified reads)

### DIFF
--- a/apps/drec-api/src/pods/issuer/services/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/services/issuer.service.ts
@@ -106,13 +106,37 @@ export class IssuerService {
 
     const certificateTransactionUID = uuid();
 
+    // Prepare certificate issuance parameters (pure — no DB writes).
+    const issuance = this.certificateService.getIssuanceParams(
+      group,
+      group.devices,
+      issueTotalReadValue,
+      minimumStartDate,
+      maximumEndDate,
+      certificateTransactionUID,
+    );
+
+    this.logger.log(
+      `Issuance: ${JSON.stringify(issuance)}, Group name: ${group.name}`,
+    );
+
+    // Issue the certificate FIRST. Everything below records "this period was
+    // issued" — marking the reads certified, the per-device and group cert
+    // logs, the megawatt-hour accounting and the reservation end. If issue()
+    // throws, none of it runs, so the reads stay uncertified and are retried
+    // on the next cycle. Previously this bookkeeping ran *before* issue(), so a
+    // failed mint left "phantom" certified reads with no certificate — and the
+    // certified flag plus the cert-log row then blocked any automatic retry.
+    await this.certificateService.issue(issuance);
+
+    // Mark the underlying reads as certified for this issuance window.
     await this.readsService.updateCertificateIssueDate(
       validReadings.map((r) => r.filteredReadings.map((fr) => fr.id)).flat(),
       startDate.toJSDate(),
       endDate.toJSDate(),
     );
 
-    // Log the certificate details
+    // Per-device certificate log.
     await Promise.all(
       validReadings.map(({ device, totalRead }) =>
         this.certificateLogService.createForDevice(
@@ -128,21 +152,8 @@ export class IssuerService {
       ),
     );
 
-    // Prepare certificate issuance parameters
-    const issuance = this.certificateService.getIssuanceParams(
-      group,
-      group.devices,
-      issueTotalReadValue,
-      minimumStartDate,
-      maximumEndDate,
-      certificateTransactionUID,
-    );
-
-    this.logger.log(
-      `Issuance: ${JSON.stringify(issuance)}, Group name: ${group.name}`,
-    );
-
-    // Calculate and update megawatt hour values
+    // Update megawatt-hour accounting and end the reservation if the target
+    // volume has now been reached.
     const totalReadValueMegaWattHour = totalReadValueKw / 1000;
 
     await this.groupService.updateTotalReadingRequestedForCertificateIssuance(
@@ -151,7 +162,6 @@ export class IssuerService {
       totalReadValueMegaWattHour,
     );
 
-    // Check if target volume reached and end reservation if needed
     const newTotalRequested =
       group.targetVolumeCertificateGenerationRequestedInMegaWattHour +
       totalReadValueMegaWattHour;
@@ -164,7 +174,7 @@ export class IssuerService {
       await this.groupService.endReservation(group.id, group, groupRequest);
     }
 
-    // Create group certificate log
+    // Group certificate log.
     await this.certificateLogService.createForGroup(
       group,
       minimumStartDate,
@@ -174,9 +184,6 @@ export class IssuerService {
       countryCodeKey,
       certificateTransactionUID,
     );
-
-    // Issue the certificate
-    return this.certificateService.issue(issuance);
   }
 
   @Profile()


### PR DESCRIPTION
## Problem
`IssuerService.issueCertificate` recorded everything as if the certificate had been minted — marked the underlying reads `certified=true`, wrote the per-device and group certificate-log rows, advanced the MWh accounting, and ended the reservation — **before** calling `certificateService.issue()`. When `issue()` failed, that state was already persisted: reads looked certified and `"Requested"` cert-log rows existed, but **no certificate was ever minted**.

Because the next issuance cycle filters `certified=false` reads (`getDeviceReading`) and the cert-log rows trip `filterOutCertifiedReads` / `hasIssuedForDeviceInWindow`, nothing retried these reads — the token never landed without manual DB cleanup.

This is the root cause of the **2026-06-20 prod "missing tokens" incident** (Hamara Grid / Fourth Partner, ~30 stranded site-months). See memory `phantom-certified-reads`.

## Fix
Reorder `issueCertificate` so `certificateService.issue()` runs **first and is the gate**. The read marking, per-device/group cert logs, volume accounting and reservation-end now run only **after** `issue()` resolves. A failed `issue()` leaves the reads `certified=false`, so the next cycle retries them cleanly instead of stranding them.

No schema/migration changes. `getIssuanceParams` is pure (no DB writes), so moving it above `issue()` is safe.

## Scope / limitations
- Fixes the **synchronous** failure mode (`issue()` throws / off-chain persist fails) — which matches this incident (no `certificate_read_model` row at all).
- Does **not** by itself cover an `issue()` that succeeds but whose async on-chain confirmation later fails. A periodic reconciliation sweep (productionising the existing `/admin/repair-stranded-mints`, whose detection boundary also needs a fix) is the follow-up for that residual.

## Testing
- `tsc --noEmit` clean.
- The `issuer.service` spec suite currently fails at TestBed DI setup (`LateOngoingIssuanceService` missing a `DataSource` provider) **on develop already**, independent of this change — verified by running the suite against the unmodified file. The called/not-called assertions it does have hold under the new ordering (no order assertions exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)