### PR TITLE
admin: /reissue-certificate endpoint + force flag (land deployed prod hotfix)

### DIFF
--- a/apps/drec-api/src/pods/admin/admin.controller.ts
+++ b/apps/drec-api/src/pods/admin/admin.controller.ts
@@ -810,6 +810,7 @@ export class AdminController {
     groupId: number;
     window: { start: string; end: string };
     dryRun: boolean;
+    force: boolean;
     requested: number;
     eligible: string[];
     skippedNotFound: string[];
@@ -836,9 +837,13 @@ export class AdminController {
     const errors: { externalId: string; message: string }[] = [];
 
     const dryRun = !!body.dryRun;
+    const force = !!body.force;
 
     // First pass: filter out missing devices and already-issued ones so the
-    // caller can see the planned set even in dryRun.
+    // caller can see the planned set even in dryRun. When `force` is set the
+    // hasIssuedForDeviceInWindow guard is bypassed — used for "phantom" cycles
+    // where a per-device cert-log row exists but no certificate was ever
+    // minted, so the guard would otherwise wrongly skip the read.
     const devicesToIssue = [];
     for (const externalId of body.externalIds) {
       const device = await this.deviceService.findByExternalId(externalId);
@@ -846,12 +851,14 @@ export class AdminController {
         skippedNotFound.push(externalId);
         continue;
       }
-      const already = await this.certificateLogService.hasIssuedForDeviceInWindow(
-        body.groupId,
-        externalId,
-        windowStart,
-        windowEnd,
-      );
+      const already = force
+        ? false
+        : await this.certificateLogService.hasIssuedForDeviceInWindow(
+            body.groupId,
+            externalId,
+            windowStart,
+            windowEnd,
+          );
       if (already) {
         skippedAlreadyIssued.push(externalId);
         continue;
@@ -865,6 +872,7 @@ export class AdminController {
         groupId: body.groupId,
         window: { start: windowStart.toISOString(), end: windowEnd.toISOString() },
         dryRun: true,
+        force,
         requested: body.externalIds.length,
         eligible,
         skippedNotFound,
@@ -879,6 +887,7 @@ export class AdminController {
         groupId: body.groupId,
         window: { start: windowStart.toISOString(), end: windowEnd.toISOString() },
         dryRun: false,
+        force,
         requested: body.externalIds.length,
         eligible,
         skippedNotFound,
@@ -915,6 +924,7 @@ export class AdminController {
       groupId: body.groupId,
       window: { start: windowStart.toISOString(), end: windowEnd.toISOString() },
       dryRun: false,
+      force,
       requested: body.externalIds.length,
       eligible,
       skippedNotFound,

--- a/apps/drec-api/src/pods/admin/admin.controller.ts
+++ b/apps/drec-api/src/pods/admin/admin.controller.ts
@@ -56,6 +56,10 @@ import { Connection } from 'typeorm';
 import { InjectConnection } from '@nestjs/typeorm';
 import { LateOngoingIssuanceService } from '../issuer/services/late-ongoing-issuance.service';
 import { RepairStrandedMintsDTO } from './dto/repair-stranded-mints.dto';
+import { IssuerService } from '../issuer/services/issuer.service';
+import { CertificateLogService } from '../certificate-log/certificate-log.service';
+import { ReissueCertificateDTO } from './dto/reissue-certificate.dto';
+import { DateTime } from 'luxon';
 @ApiTags('Admin')
 @ApiBearerAuth('access-token')
 @Controller('admin')
@@ -70,6 +74,8 @@ export class AdminController {
     private readonly invitationService: InvitationService,
     @InjectConnection() private readonly connection: Connection,
     private readonly lateOngoingIssuanceService: LateOngoingIssuanceService,
+    private readonly issuerService: IssuerService,
+    private readonly certificateLogService: CertificateLogService,
   ) {}
 
   @Get('/users')
@@ -771,6 +777,150 @@ export class AdminController {
       strandedCount: stranded.length,
       stranded: summary,
       repaired: { logRowsCleared, readsReset, cyclesInserted },
+    };
+  }
+
+  /**
+   * Admin manual reissue. Reissues certificates for the given device externalIds
+   * against the given reservation (groupId), over a specified or default window
+   * (defaults to group.reservationStartDate..reservationEndDate).
+   *
+   * Why this exists: the legacy endReservation() cascade unlinked devices the
+   * moment reservationEndDate passed, leaving any in-window reads unminted.
+   * The DB-level repair restored device.groupId for the orphaned set, but in
+   * cases where devices have since been re-attached to a follow-on reservation
+   * (e.g. 69115b → 88079), the only safe way to mint the missed window is a
+   * targeted reissue that doesn't touch the current FK.
+   *
+   * Idempotent: devices that already have a per-device certificate log row
+   * overlapping the target window are skipped. Pass `dryRun: true` to preview
+   * without writing.
+   */
+  @Post('/reissue-certificate')
+  @Roles(Role.Admin)
+  @Permission('Write')
+  @ACLModules('ADMIN_MANAGEMENT_CRUDL')
+  @ApiOperation({
+    summary: 'Manually reissue certificates for a (group, externalIds, window) tuple',
+  })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Reissue summary.' })
+  public async reissueCertificate(
+    @Body() body: ReissueCertificateDTO,
+  ): Promise<{
+    groupId: number;
+    window: { start: string; end: string };
+    dryRun: boolean;
+    requested: number;
+    eligible: string[];
+    skippedNotFound: string[];
+    skippedAlreadyIssued: string[];
+    issued: string[];
+    errors: { externalId: string; message: string }[];
+  }> {
+    const group = await this.deviceGroupService.adminFindGroupById(body.groupId);
+    if (!group) {
+      throw new NotFoundException(`No device_group with id ${body.groupId}`);
+    }
+
+    const windowStart = body.startDate
+      ? new Date(body.startDate)
+      : new Date(group.reservationStartDate);
+    const windowEnd = body.endDate
+      ? new Date(body.endDate)
+      : new Date(group.reservationEndDate);
+
+    const eligible: string[] = [];
+    const skippedNotFound: string[] = [];
+    const skippedAlreadyIssued: string[] = [];
+    const issued: string[] = [];
+    const errors: { externalId: string; message: string }[] = [];
+
+    const dryRun = !!body.dryRun;
+
+    // First pass: filter out missing devices and already-issued ones so the
+    // caller can see the planned set even in dryRun.
+    const devicesToIssue = [];
+    for (const externalId of body.externalIds) {
+      const device = await this.deviceService.findByExternalId(externalId);
+      if (!device) {
+        skippedNotFound.push(externalId);
+        continue;
+      }
+      const already = await this.certificateLogService.hasIssuedForDeviceInWindow(
+        body.groupId,
+        externalId,
+        windowStart,
+        windowEnd,
+      );
+      if (already) {
+        skippedAlreadyIssued.push(externalId);
+        continue;
+      }
+      eligible.push(externalId);
+      devicesToIssue.push(device);
+    }
+
+    if (dryRun) {
+      return {
+        groupId: body.groupId,
+        window: { start: windowStart.toISOString(), end: windowEnd.toISOString() },
+        dryRun: true,
+        requested: body.externalIds.length,
+        eligible,
+        skippedNotFound,
+        skippedAlreadyIssued,
+        issued: [],
+        errors: [],
+      };
+    }
+
+    if (devicesToIssue.length === 0) {
+      return {
+        groupId: body.groupId,
+        window: { start: windowStart.toISOString(), end: windowEnd.toISOString() },
+        dryRun: false,
+        requested: body.externalIds.length,
+        eligible,
+        skippedNotFound,
+        skippedAlreadyIssued,
+        issued: [],
+        errors: [],
+      };
+    }
+
+    // The issuer reads group.devices to know which devices' reads to total
+    // and mint against. We hand-assemble the device list rather than relying
+    // on device.groupId so devices currently attached to another reservation
+    // (e.g. moved to a follow-on PO) can still be reissued for this older
+    // window. Per-device so one bad device doesn't poison the whole batch.
+    for (const device of devicesToIssue) {
+      try {
+        const issuanceGroup = { ...group, devices: [device] } as typeof group;
+        await this.issuerService.issueCertificate(
+          issuanceGroup,
+          // nextIssuance is only used for cycle bookkeeping that doesn't apply
+          // to a one-shot manual reissue; passing a minimal stub is fine.
+          { id: 0 } as any,
+          DateTime.fromJSDate(windowStart).toUTC(),
+          DateTime.fromJSDate(windowEnd).toUTC(),
+          device.countryCode,
+        );
+        issued.push(device.externalId);
+      } catch (e: any) {
+        errors.push({ externalId: device.externalId, message: e?.message ?? String(e) });
+      }
+    }
+
+    return {
+      groupId: body.groupId,
+      window: { start: windowStart.toISOString(), end: windowEnd.toISOString() },
+      dryRun: false,
+      requested: body.externalIds.length,
+      eligible,
+      skippedNotFound,
+      skippedAlreadyIssued,
+      issued,
+      errors,
     };
   }
 }

--- a/apps/drec-api/src/pods/admin/admin.module.ts
+++ b/apps/drec-api/src/pods/admin/admin.module.ts
@@ -9,6 +9,8 @@ import { DeviceModule } from '../device';
 import { DeviceGroupModule } from '../device-group/device-group.module';
 import { InvitationModule } from '../invitation/invitation.module';
 import { IssuerModule } from '../issuer/issuer.module';
+import { CertificateLogModule } from '../certificate-log/certificate-log.module';
+import { ReadsModule } from '../reads/reads.module';
 
 @Module({
   imports: [
@@ -19,6 +21,8 @@ import { IssuerModule } from '../issuer/issuer.module';
     DeviceGroupModule,
     InvitationModule,
     forwardRef(() => IssuerModule),
+    CertificateLogModule,
+    ReadsModule,
   ],
   controllers: [AdminController],
 })

--- a/apps/drec-api/src/pods/admin/dto/reissue-certificate.dto.ts
+++ b/apps/drec-api/src/pods/admin/dto/reissue-certificate.dto.ts
@@ -56,4 +56,17 @@ export class ReissueCertificateDTO {
   @IsOptional()
   @IsBoolean()
   dryRun?: boolean;
+
+  @ApiPropertyOptional({
+    type: Boolean,
+    description:
+      'When true, bypass the hasIssuedForDeviceInWindow idempotency guard and ' +
+      'reissue even if a per-device certificate-log row overlaps the window. For ' +
+      '"phantom" cycles where the log says issued but no certificate was minted. ' +
+      'Use only after confirming no real certificate exists for the window.',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  force?: boolean;
 }

--- a/apps/drec-api/src/pods/admin/dto/reissue-certificate.dto.ts
+++ b/apps/drec-api/src/pods/admin/dto/reissue-certificate.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+/**
+ * Admin manual reissue. Targets a specific reservation (groupId) plus a list of
+ * device externalIds, and re-runs the issuance pipeline over a date window —
+ * intended for cleanup after the endReservation cascade prematurely unlinked
+ * devices, leaving in-window reads unminted. Idempotent: skips devices that
+ * already have a certificate log entry covering the target window.
+ */
+export class ReissueCertificateDTO {
+  @ApiProperty({ type: Number, description: 'Target device_group.id' })
+  @IsInt()
+  groupId: number;
+
+  @ApiProperty({
+    type: [String],
+    description: 'externalIds of devices whose reads should be reissued',
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsString({ each: true })
+  externalIds: string[];
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Window start (ISO8601). Defaults to group.reservationStartDate.',
+  })
+  @IsOptional()
+  @IsISO8601()
+  startDate?: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description: 'Window end (ISO8601). Defaults to group.reservationEndDate.',
+  })
+  @IsOptional()
+  @IsISO8601()
+  endDate?: string;
+
+  @ApiPropertyOptional({
+    type: Boolean,
+    description:
+      'When true, report what would happen without writing certificates or DB log rows.',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  dryRun?: boolean;
+}

--- a/apps/drec-api/src/pods/certificate-log/certificate-log.service.ts
+++ b/apps/drec-api/src/pods/certificate-log/certificate-log.service.ts
@@ -76,6 +76,33 @@ export class CertificateLogService {
     });
   }
 
+  /**
+   * Has a per-device certificate log row already been written for the given
+   * (group, externalId, ongoing window)? Used by admin reissue to skip
+   * already-minted devices and stay idempotent. Window matching is on
+   * ongoing_start_date / ongoing_end_date because that's what the issuance
+   * pipeline stamps; certificate_issuance_start/end use the trimmed read
+   * range and can drift slightly even for the same logical cycle.
+   */
+  public async hasIssuedForDeviceInWindow(
+    groupId: number,
+    externalId: string,
+    windowStart: Date,
+    windowEnd: Date,
+  ): Promise<boolean> {
+    const count = await this.repository
+      .createQueryBuilder('log')
+      .where('log."groupId" = :groupId', { groupId })
+      .andWhere('log."externalId" = :externalId', { externalId })
+      .andWhere('log.ongoing_start_date IS NOT NULL')
+      .andWhere(
+        '(log.ongoing_start_date::timestamptz, log.ongoing_end_date::timestamptz) OVERLAPS (:s::timestamptz, :e::timestamptz)',
+        { s: windowStart.toISOString(), e: windowEnd.toISOString() },
+      )
+      .getCount();
+    return count > 0;
+  }
+
   async findCertificateLog(): Promise<
     CheckCertificateIssueDateLogForDeviceEntity[]
   > {

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -1206,6 +1206,11 @@ export class DeviceGroupService {
     }
   }
 
+  /** Admin lookup: load any device_group by id regardless of org. */
+  public async adminFindGroupById(id: number): Promise<DeviceGroup | null> {
+    return this.repository.findOne({ where: { id } });
+  }
+
   private async findDeviceGroupById(
     id: number,
     organizationId: number,

--- a/apps/drec-api/src/pods/device/device.service.ts
+++ b/apps/drec-api/src/pods/device/device.service.ts
@@ -456,6 +456,13 @@ export class DeviceService {
     return device;
   }
 
+  async findByExternalId(externalId: string): Promise<Device | null> {
+    const device = await this.repository.findOne({
+      where: { externalId },
+    });
+    return device ?? null;
+  }
+
   @Profile()
   async findReads(meterId: string): Promise<Device | null> {
     this.logger.verbose(`With in findReads`);


### PR DESCRIPTION
## Why
Backfills the prod branch with the targeted manual-reissue endpoint used to remediate the **2026-06-20 "missing tokens" incident**. This code is **already running on prod** (manually-built image `prod-58ac92b9…`, deployed during the incident); the prod branch never had it, so without this PR the next CI prod deploy would silently drop the endpoint. Rollback image is `prod-d1e72879…`.

## What
- **`POST /admin/reissue-certificate`** (cherry-pick of develop `8ddd2e05`) — targeted manual reissue for a `(group, externalIds, window)` tuple, idempotent, with `dryRun`. Conflicts in `admin.controller`/`admin.module` were resolved by union with prod's existing late-ongoing / stranded-mint deps; backported `DeviceService.findByExternalId` (the handler depends on it and prod's build lacked it).
- **`force` flag** on the same endpoint — bypasses the `hasIssuedForDeviceInWindow` guard for "phantom" cycles where a per-device cert-log row exists but no certificate was ever minted. Safe because the operator confirms no real certificate exists first.

No schema/migration changes; additive only.

## Relationship to the root-cause fix
This is the **operational tool** to clean up stranded mints. The **root cause** (reads marked certified before the mint succeeds) is fixed separately for develop in #784. The two are independent and both wanted.

## Note on usage
The endpoint alone is necessary but not sufficient for phantom cycles — `filterOutCertifiedReads` also drops reads whose period overlaps a cert-log row, so the phantom per-device log rows must be deleted before the forced reissue will total the reads. Procedure documented in memory `phantom-certified-reads`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)