### PR TITLE
fix(issuer): mark reads certified only after mint succeeds (prod hotfix)

### DIFF
--- a/apps/drec-api/src/pods/issuer/services/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/services/issuer.service.ts
@@ -106,13 +106,37 @@ export class IssuerService {
 
     const certificateTransactionUID = uuid();
 
+    // Prepare certificate issuance parameters (pure — no DB writes).
+    const issuance = this.certificateService.getIssuanceParams(
+      group,
+      group.devices,
+      issueTotalReadValue,
+      minimumStartDate,
+      maximumEndDate,
+      certificateTransactionUID,
+    );
+
+    this.logger.log(
+      `Issuance: ${JSON.stringify(issuance)}, Group name: ${group.name}`,
+    );
+
+    // Issue the certificate FIRST. Everything below records "this period was
+    // issued" — marking the reads certified, the per-device and group cert
+    // logs, the megawatt-hour accounting and the reservation end. If issue()
+    // throws, none of it runs, so the reads stay uncertified and are retried
+    // on the next cycle. Previously this bookkeeping ran *before* issue(), so a
+    // failed mint left "phantom" certified reads with no certificate — and the
+    // certified flag plus the cert-log row then blocked any automatic retry.
+    await this.certificateService.issue(issuance);
+
+    // Mark the underlying reads as certified for this issuance window.
     await this.readsService.updateCertificateIssueDate(
       validReadings.map((r) => r.filteredReadings.map((fr) => fr.id)).flat(),
       startDate.toJSDate(),
       endDate.toJSDate(),
     );
 
-    // Log the certificate details
+    // Per-device certificate log.
     await Promise.all(
       validReadings.map(({ device, totalRead }) =>
         this.certificateLogService.createForDevice(
@@ -128,21 +152,8 @@ export class IssuerService {
       ),
     );
 
-    // Prepare certificate issuance parameters
-    const issuance = this.certificateService.getIssuanceParams(
-      group,
-      group.devices,
-      issueTotalReadValue,
-      minimumStartDate,
-      maximumEndDate,
-      certificateTransactionUID,
-    );
-
-    this.logger.log(
-      `Issuance: ${JSON.stringify(issuance)}, Group name: ${group.name}`,
-    );
-
-    // Calculate and update megawatt hour values
+    // Update megawatt-hour accounting and end the reservation if the target
+    // volume has now been reached.
     const totalReadValueMegaWattHour = totalReadValueKw / 1000;
 
     await this.groupService.updateTotalReadingRequestedForCertificateIssuance(
@@ -151,7 +162,6 @@ export class IssuerService {
       totalReadValueMegaWattHour,
     );
 
-    // Check if target volume reached and end reservation if needed
     const newTotalRequested =
       group.targetVolumeCertificateGenerationRequestedInMegaWattHour +
       totalReadValueMegaWattHour;
@@ -164,7 +174,7 @@ export class IssuerService {
       await this.groupService.endReservation(group.id, group, groupRequest);
     }
 
-    // Create group certificate log
+    // Group certificate log.
     await this.certificateLogService.createForGroup(
       group,
       minimumStartDate,
@@ -174,9 +184,6 @@ export class IssuerService {
       countryCodeKey,
       certificateTransactionUID,
     );
-
-    // Issue the certificate
-    return this.certificateService.issue(issuance);
   }
 
   @Profile()


### PR DESCRIPTION
Prod cherry-pick of the phantom-certified root-cause fix (develop `b3aa2f26` / `acca658b`), for review.

## What it fixes
`issueCertificate` marked the underlying reads `certified=true`, wrote the per-device/group certificate-log rows, advanced the MWh accounting, and ended the reservation — **all before** calling `certificateService.issue()`. If the mint then failed, that state was already persisted: reads looked certified and "Requested" cert-log rows existed, but no certificate was ever minted. The `certified` flag + log rows then blocked every automatic retry, so the token never landed without manual cleanup ("phantom-certified reads").

This produced the 2026-06-20 Hamara Grid / Fourth Partner "missing tokens" incident, and a fresh 2026 instance (EMITS 10001) remediated by hand on 2026-07-14.

## The change
Reorder so `certificateService.issue()` runs **first and is the gate** — read-marking, cert logs, volume accounting, and reservation-end only run after it resolves. A failed `issue()` now leaves the reads uncertified so the next cycle retries them cleanly. One file, +28/-21; clean cherry-pick (auto-merged, no conflicts). Verified: tsc 0, prettier + eslint clean, `issuer.service.spec` 34/34.

## ⚠️ Deploy caveat — read before merging
Prod is currently **running the hand-built image `prod-58ac92b9`**, which carries the `POST /admin/reissue-certificate` endpoint that the `prod` branch tip (`d1e72879`) does **not** have. Merging this PR and letting CI build a prod image from the branch would produce `d1e72879 + this fix` and **drop the hand-built reissue endpoint** (rollback image: `prod-d1e72879`).

So this should **not** be deployed on its own — it needs to be coordinated with landing the reissue endpoint on `prod` (the separate PR #785 `prod-reissue-hotfix`), i.e. merge both together (or rebase this on top of that) so the next prod image has both. Flagging for your call on sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)