### PR TITLE
issuer: k8s-restartable liveness endpoint for stalled mint worker

### DIFF
--- a/apps/drec-api/src/pods/health/health.controller.ts
+++ b/apps/drec-api/src/pods/health/health.controller.ts
@@ -14,6 +14,7 @@ import {
 } from '@nestjs/terminus';
 import { redisOptions } from '../../drec.module';
 import { RedisHealthIndicator } from './redis.health-indicator';
+import { IssuanceWorkerHealthIndicator } from './issuance-worker.health-indicator';
 
 @ApiTags('Health')
 @Controller('health')
@@ -23,6 +24,7 @@ export class HealthController {
     private db: TypeOrmHealthIndicator,
     private redis: RedisHealthIndicator,
     private http: HttpHealthIndicator,
+    private issuanceWorker: IssuanceWorkerHealthIndicator,
   ) {}
 
   @Get()
@@ -57,6 +59,26 @@ export class HealthController {
           'redis',
           `redis://${redisOptions.host}:${redisOptions.port}`,
         ),
+    ]);
+  }
+
+  @Get('/issuance-worker')
+  @ApiOperation({
+    summary: 'Issuance worker liveness',
+    description:
+      'Returns 503 when the late-ongoing BullMQ mint worker has stalled ' +
+      '(pending cycles exist but no cycle has been checked for >9h). Intended ' +
+      'as a k8s livenessProbe target so a stuck worker triggers an automatic ' +
+      'pod restart — the proven remedy for the ioredis connection-drop stall.',
+  })
+  @ApiResponse({
+    status: HttpStatus.SERVICE_UNAVAILABLE,
+    description: 'The late-ongoing issuance worker appears stalled',
+  })
+  @HealthCheck()
+  issuanceWorkerLiveness(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.issuanceWorker.isHealthy('issuance_worker'),
     ]);
   }
 }

--- a/apps/drec-api/src/pods/health/health.module.ts
+++ b/apps/drec-api/src/pods/health/health.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
 import { RedisHealthIndicator } from './redis.health-indicator';
+import { IssuanceWorkerHealthIndicator } from './issuance-worker.health-indicator';
 
 @Module({
   imports: [TerminusModule],
-  providers: [RedisHealthIndicator],
+  providers: [RedisHealthIndicator, IssuanceWorkerHealthIndicator],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/apps/drec-api/src/pods/health/issuance-worker.health-indicator.spec.ts
+++ b/apps/drec-api/src/pods/health/issuance-worker.health-indicator.spec.ts
@@ -1,0 +1,43 @@
+import { HealthCheckError } from '@nestjs/terminus';
+import { Connection } from 'typeorm';
+import { IssuanceWorkerHealthIndicator } from './issuance-worker.health-indicator';
+
+describe('IssuanceWorkerHealthIndicator', () => {
+  const build = (query: jest.Mock) =>
+    new IssuanceWorkerHealthIndicator({ query } as unknown as Connection);
+
+  const hoursAgoIso = (h: number) =>
+    new Date(Date.now() - h * 3600 * 1000).toISOString();
+
+  it('reports healthy when the worker is progressing', async () => {
+    const indicator = build(
+      jest
+        .fn()
+        .mockResolvedValue([{ pending: '100', last_checked: hoursAgoIso(1) }]),
+    );
+    const res = await indicator.isHealthy('issuance_worker');
+    expect(res.issuance_worker.status).toBe('up');
+  });
+
+  it('throws HealthCheckError (→ 503) when the worker is stalled', async () => {
+    const indicator = build(
+      jest
+        .fn()
+        .mockResolvedValue([
+          { pending: '748843', last_checked: hoursAgoIso(131) },
+        ]),
+    );
+    await expect(indicator.isHealthy('issuance_worker')).rejects.toBeInstanceOf(
+      HealthCheckError,
+    );
+  });
+
+  it('FAILS OPEN (healthy) when the cycle query throws — no restart cascade on DB blips', async () => {
+    const indicator = build(
+      jest.fn().mockRejectedValue(new Error('connection terminated')),
+    );
+    const res = await indicator.isHealthy('issuance_worker');
+    expect(res.issuance_worker.status).toBe('up');
+    expect(res.issuance_worker.checkSkipped).toBe(true);
+  });
+});

--- a/apps/drec-api/src/pods/health/issuance-worker.health-indicator.ts
+++ b/apps/drec-api/src/pods/health/issuance-worker.health-indicator.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import {
   HealthCheckError,
   HealthIndicator,
@@ -14,24 +14,47 @@ import {
 
 /**
  * Terminus indicator that goes unhealthy when the late-ongoing BullMQ mint
- * worker has stalled (pending cycles but no progress for >9h). Wire the
- * /health/issuance-worker endpoint as a k8s livenessProbe so a stuck worker
+ * worker has stalled (pending cycles but no progress for >9h). Point a k8s
+ * livenessProbe at the /health/issuance-worker endpoint so a stuck worker
  * triggers an automatic pod restart — the proven remedy for the ioredis
  * connection-drop stall (see late-ongoing-worker-health.ts).
  *
  * Queries the DB directly rather than depending on IssuerModule, to avoid
  * coupling HealthModule to the issuer graph; the stall logic itself is shared.
+ *
+ * FAILS OPEN on query error. This endpoint is intended for the liveness path,
+ * where the existing container already has exactly one livenessProbe — so
+ * repointing it here means a DB query now sits on the restart path. We must
+ * only restart on POSITIVE evidence of a stalled worker (DB reachable AND
+ * cycles pending AND stale). If the query itself throws (DB briefly
+ * unreachable), returning unhealthy would restart every api pod in a cascade
+ * during a DB incident. So an errored/inconclusive check reports healthy.
  */
 @Injectable()
 export class IssuanceWorkerHealthIndicator extends HealthIndicator {
+  private readonly logger = new Logger(IssuanceWorkerHealthIndicator.name);
+
   constructor(@InjectConnection() private readonly connection: Connection) {
     super();
   }
 
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
-    const [row] = (await this.connection.query(
-      LATE_ONGOING_WORKER_HEALTH_SQL,
-    )) as LateOngoingWorkerHealthRow[];
+    let row: LateOngoingWorkerHealthRow;
+    try {
+      [row] = (await this.connection.query(
+        LATE_ONGOING_WORKER_HEALTH_SQL,
+      )) as LateOngoingWorkerHealthRow[];
+    } catch (err) {
+      // Fail open: an unreachable DB is not evidence of a stalled worker, and
+      // must never cascade into a restart loop. The DB's own health check
+      // (/health/status) is the right place to surface DB outages.
+      this.logger.error(
+        `issuance-worker liveness check could not query cycles, reporting healthy: ${
+          (err as Error).message
+        }`,
+      );
+      return this.getStatus(key, true, { checkSkipped: true });
+    }
 
     const health = evaluateLateOngoingWorkerHealth(row, Date.now());
 

--- a/apps/drec-api/src/pods/health/issuance-worker.health-indicator.ts
+++ b/apps/drec-api/src/pods/health/issuance-worker.health-indicator.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthCheckError,
+  HealthIndicator,
+  HealthIndicatorResult,
+} from '@nestjs/terminus';
+import { InjectConnection } from '@nestjs/typeorm';
+import { Connection } from 'typeorm';
+import {
+  LATE_ONGOING_WORKER_HEALTH_SQL,
+  LateOngoingWorkerHealthRow,
+  evaluateLateOngoingWorkerHealth,
+} from '../issuer/services/late-ongoing-worker-health';
+
+/**
+ * Terminus indicator that goes unhealthy when the late-ongoing BullMQ mint
+ * worker has stalled (pending cycles but no progress for >9h). Wire the
+ * /health/issuance-worker endpoint as a k8s livenessProbe so a stuck worker
+ * triggers an automatic pod restart — the proven remedy for the ioredis
+ * connection-drop stall (see late-ongoing-worker-health.ts).
+ *
+ * Queries the DB directly rather than depending on IssuerModule, to avoid
+ * coupling HealthModule to the issuer graph; the stall logic itself is shared.
+ */
+@Injectable()
+export class IssuanceWorkerHealthIndicator extends HealthIndicator {
+  constructor(@InjectConnection() private readonly connection: Connection) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const [row] = (await this.connection.query(
+      LATE_ONGOING_WORKER_HEALTH_SQL,
+    )) as LateOngoingWorkerHealthRow[];
+
+    const health = evaluateLateOngoingWorkerHealth(row, Date.now());
+
+    const result = this.getStatus(key, !health.stalled, {
+      pending: health.pending,
+      lastCheckedAt: health.lastChecked,
+      ageHours: health.ageHours,
+    });
+
+    if (health.stalled) {
+      throw new HealthCheckError(
+        `late-ongoing issuance worker stalled: ${health.reason}`,
+        result,
+      );
+    }
+
+    return result;
+  }
+}

--- a/apps/drec-api/src/pods/issuer/services/late-ongoing-issuance.service.ts
+++ b/apps/drec-api/src/pods/issuer/services/late-ongoing-issuance.service.ts
@@ -21,6 +21,11 @@ import { IssuerService } from './issuer.service';
 import { Profile } from '../../../lib/profile';
 import { CronExpression } from '@nestjs/schedule';
 import { ReadType } from '../../../utils/enums';
+import {
+  LATE_ONGOING_WORKER_HEALTH_SQL,
+  LateOngoingWorkerHealthRow,
+  evaluateLateOngoingWorkerHealth,
+} from './late-ongoing-worker-health';
 
 @Injectable()
 export class LateOngoingIssuanceService {
@@ -54,40 +59,28 @@ export class LateOngoingIssuanceService {
   @NonConcurrentCron(CronExpression.EVERY_30_MINUTES)
   async monitorIssuanceWorkerHealth(): Promise<void> {
     try {
-      const [{ pending, last_checked }] = (await this.connection.query(
-        `SELECT
-           COUNT(*) FILTER (WHERE certificate_issued=false AND archived_at IS NULL) AS pending,
-           MAX(checked_at) AS last_checked
-         FROM device_lateongoing_certificate_cycle`,
-      )) as { pending: string; last_checked: Date | null }[];
-      const pendingNum = Number(pending);
-      if (pendingNum === 0) return;
-      if (!last_checked) {
-        const msg =
-          'Late-ongoing worker liveness: pending cycles exist but no cycle has ever been checked. Worker may not be running.';
-        this.logger.error(msg);
-        Sentry.captureMessage(msg, 'error');
-        return;
-      }
-      const ageMs = Date.now() - new Date(last_checked).getTime();
-      const STALE_AFTER_MS = 9 * 60 * 60 * 1000;
-      if (ageMs > STALE_AFTER_MS) {
-        const ageH = (ageMs / 1000 / 3600).toFixed(1);
-        const msg =
-          `Late-ongoing worker appears stalled: ${pendingNum} pending cycle(s), ` +
-          `last checked_at ${ageH}h ago (threshold ${STALE_AFTER_MS / 1000 / 3600}h). ` +
-          `Likely a stuck BullMQ worker — restart the api pod to recover.`;
-        this.logger.error(msg);
-        Sentry.captureMessage(msg, {
-          level: 'error',
-          tags: { check: 'late_ongoing_worker_liveness' },
-          extra: {
-            pending: pendingNum,
-            lastCheckedAt: last_checked,
-            ageHours: Number(ageH),
-          },
-        });
-      }
+      const [row] = (await this.connection.query(
+        LATE_ONGOING_WORKER_HEALTH_SQL,
+      )) as LateOngoingWorkerHealthRow[];
+
+      const health = evaluateLateOngoingWorkerHealth(row, Date.now());
+      if (!health.stalled) return;
+
+      // Same signal the /health/issuance-worker probe reports; here we make it
+      // loud (log + Sentry) in case the k8s livenessProbe isn't wired yet.
+      const msg =
+        `Late-ongoing worker appears stalled: ${health.reason}. ` +
+        `Likely a stuck BullMQ worker — restart the api pod to recover.`;
+      this.logger.error(msg);
+      Sentry.captureMessage(msg, {
+        level: 'error',
+        tags: { check: 'late_ongoing_worker_liveness' },
+        extra: {
+          pending: health.pending,
+          lastCheckedAt: health.lastChecked,
+          ageHours: health.ageHours,
+        },
+      });
     } catch (err) {
       this.logger.error(
         `monitorIssuanceWorkerHealth failed: ${(err as Error).message}`,

--- a/apps/drec-api/src/pods/issuer/services/late-ongoing-worker-health.spec.ts
+++ b/apps/drec-api/src/pods/issuer/services/late-ongoing-worker-health.spec.ts
@@ -1,0 +1,67 @@
+import {
+  LATE_ONGOING_WORKER_STALE_AFTER_MS,
+  evaluateLateOngoingWorkerHealth,
+} from './late-ongoing-worker-health';
+
+describe('evaluateLateOngoingWorkerHealth', () => {
+  const now = new Date('2026-08-06T12:00:00.000Z').getTime();
+  const hoursAgo = (h: number) => new Date(now - h * 3600 * 1000);
+
+  it('is healthy when there is no pending work, regardless of staleness', () => {
+    const h = evaluateLateOngoingWorkerHealth(
+      { pending: 0, last_checked: hoursAgo(999) },
+      now,
+    );
+    expect(h.stalled).toBe(false);
+    expect(h.pending).toBe(0);
+  });
+
+  it('is healthy when pending work was checked recently', () => {
+    const h = evaluateLateOngoingWorkerHealth(
+      { pending: 500, last_checked: hoursAgo(1) },
+      now,
+    );
+    expect(h.stalled).toBe(false);
+    expect(h.ageHours).toBeCloseTo(1, 1);
+  });
+
+  it('is stalled when pending work has not been checked past the threshold', () => {
+    const h = evaluateLateOngoingWorkerHealth(
+      { pending: 748843, last_checked: hoursAgo(131.2) },
+      now,
+    );
+    expect(h.stalled).toBe(true);
+    expect(h.pending).toBe(748843);
+    expect(h.reason).toContain('748843 pending');
+    expect(h.reason).toContain('131.2h ago');
+  });
+
+  it('is stalled when pending work exists but nothing was ever checked', () => {
+    const h = evaluateLateOngoingWorkerHealth(
+      { pending: 10, last_checked: null },
+      now,
+    );
+    expect(h.stalled).toBe(true);
+    expect(h.reason).toContain('ever been checked');
+  });
+
+  it('treats the threshold boundary as not-yet-stalled', () => {
+    const h = evaluateLateOngoingWorkerHealth(
+      {
+        pending: 1,
+        last_checked: new Date(now - LATE_ONGOING_WORKER_STALE_AFTER_MS),
+      },
+      now,
+    );
+    expect(h.stalled).toBe(false);
+  });
+
+  it('accepts string aggregates from the raw pg driver', () => {
+    const h = evaluateLateOngoingWorkerHealth(
+      { pending: '5', last_checked: hoursAgo(20).toISOString() },
+      now,
+    );
+    expect(h.pending).toBe(5);
+    expect(h.stalled).toBe(true);
+  });
+});

--- a/apps/drec-api/src/pods/issuer/services/late-ongoing-worker-health.ts
+++ b/apps/drec-api/src/pods/issuer/services/late-ongoing-worker-health.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared stall-detection logic for the late-ongoing BullMQ mint worker.
+ *
+ * Used by two callers that must agree on what "stalled" means:
+ *  - LateOngoingIssuanceService.monitorIssuanceWorkerHealth (30-min cron → log + Sentry)
+ *  - IssuanceWorkerHealthIndicator (Terminus → 503 → k8s livenessProbe → pod restart)
+ *
+ * Background: on 2026-07-28 the prod api pod crashed on an ioredis
+ * "Connection is closed" and restarted, but the BullMQ worker came back dead.
+ * processIssuance minted nothing for ~5.5 days while createMissingCycles (not
+ * queue-bound) kept piling up cycles. The detector added in #778 caught it but
+ * only logged "restart the api pod to recover" — nobody saw the log. This helper
+ * lets a k8s livenessProbe act on the same signal automatically.
+ */
+
+/**
+ * How stale the newest checked_at may get before we call the worker stalled.
+ * One 8-hour scheduleIssuance interval + 1h margin. The worker should touch a
+ * cycle within seconds of each cron, so 9h of silence with pending work means
+ * it has stopped consuming.
+ */
+export const LATE_ONGOING_WORKER_STALE_AFTER_MS = 9 * 60 * 60 * 1000;
+
+/** Aggregate over the cycle table: how much work is pending and when a cycle was last touched. */
+export const LATE_ONGOING_WORKER_HEALTH_SQL = `SELECT
+   COUNT(*) FILTER (WHERE certificate_issued=false AND archived_at IS NULL) AS pending,
+   MAX(checked_at) AS last_checked
+ FROM device_lateongoing_certificate_cycle`;
+
+export interface LateOngoingWorkerHealthRow {
+  pending: string | number;
+  last_checked: Date | string | null;
+}
+
+export interface LateOngoingWorkerHealth {
+  pending: number;
+  lastChecked: Date | null;
+  ageMs: number | null;
+  ageHours: number | null;
+  stalled: boolean;
+  /** Human-readable reason, present only when stalled. */
+  reason?: string;
+}
+
+/**
+ * Pure evaluation of the aggregate row against the staleness threshold.
+ * `now` is injected so this is deterministic and unit-testable.
+ */
+export function evaluateLateOngoingWorkerHealth(
+  row: LateOngoingWorkerHealthRow,
+  now: number,
+): LateOngoingWorkerHealth {
+  const pending = Number(row.pending);
+
+  // No pending work → nothing for the worker to do → not stalled by definition.
+  if (!pending) {
+    return {
+      pending: 0,
+      lastChecked: null,
+      ageMs: null,
+      ageHours: null,
+      stalled: false,
+    };
+  }
+
+  // Pending work but no cycle has ever been checked → worker likely never ran.
+  if (!row.last_checked) {
+    return {
+      pending,
+      lastChecked: null,
+      ageMs: null,
+      ageHours: null,
+      stalled: true,
+      reason:
+        'pending cycles exist but no cycle has ever been checked — worker may not be running',
+    };
+  }
+
+  const lastChecked = new Date(row.last_checked);
+  const ageMs = now - lastChecked.getTime();
+  const ageHours = Number((ageMs / 1000 / 3600).toFixed(1));
+  const stalled = ageMs > LATE_ONGOING_WORKER_STALE_AFTER_MS;
+
+  return {
+    pending,
+    lastChecked,
+    ageMs,
+    ageHours,
+    stalled,
+    reason: stalled
+      ? `${pending} pending cycle(s), last checked_at ${ageHours}h ago ` +
+        `(threshold ${LATE_ONGOING_WORKER_STALE_AFTER_MS / 1000 / 3600}h)`
+      : undefined,
+  };
+}


### PR DESCRIPTION
## Why

On **2026-07-28** the prod `drec-api` container crashed on an ioredis `Connection is closed` (the recurring connection-leak) and restarted — but the **BullMQ late-ongoing mint worker came back dead**. `processIssuance` minted nothing for **~5.5 days** while `createMissingCycles` (not queue-bound) kept running, piling up **748,843 unissued cycles** (~720k of them PowerTrust's). We only found out when the customer emailed "applied ~220 reads, nothing came through."

#778 already added a detector (`monitorIssuanceWorkerHealth`, 30-min cron) — and it *worked*, logging every 30 min:

> `Late-ongoing worker appears stalled: 301593 pending cycle(s), last checked_at 131.2h ago … Likely a stuck BullMQ worker — restart the api pod to recover.`

**But it only logs.** Nobody read the log for 5.5 days. Manually `kubectl rollout restart deployment/drec-api -n prod` fixed it instantly (worker resumed, backlog draining). This PR lets **k8s do that restart automatically**.

## What

- **`late-ongoing-worker-health.ts`** — extracts the stall logic (aggregate SQL, 9h threshold, decision) into a **pure, unit-tested** helper so the cron and the new probe can't drift apart.
- **`monitorIssuanceWorkerHealth`** — refactored onto the helper; same log + Sentry behaviour.
- **`IssuanceWorkerHealthIndicator` + `GET /api/health/issuance-worker`** — Terminus check returning **503** when pending cycles exist but nothing's been checked for >9h. Body reports `{pending, lastCheckedAt, ageHours}`.
- 6 unit tests on the evaluator (healthy / recent / stalled / never-checked / boundary / pg-string-aggregates).

Threshold unchanged from #778: 9h = one 8h `scheduleIssuance` interval + 1h margin. Won't false-trip on a normal cron gap.

## ⚠️ Required infra follow-up (separate manifests repo — not in this repo)

The endpoint is **inert until a livenessProbe points at it.** Add to the `drec-api` container in prod (and stage):

```yaml
livenessProbe:
  httpGet:
    path: /api/health/issuance-worker
    port: 3040          # confirm container port
  initialDelaySeconds: 120
  periodSeconds: 60
  failureThreshold: 5   # ~5 min of continuous 503 before restart
  timeoutSeconds: 10
```

`failureThreshold × periodSeconds` (~5 min) is the debounce so a transient blip never restarts the pod; the 9h data threshold is the real gate. **Do not** point the *readiness* probe at this — a stalled worker still serves API traffic fine; we only want a restart, not to pull it from the LB.

Optional belt-and-suspenders alert (no code): CloudWatch metric filter on the existing log string → alarm → Slack:
```
filter pattern:  "Late-ongoing worker appears stalled"
```

## Notes / trade-offs
- Deliberately **not** `process.exit()` from the cron — blunt, interrupts in-flight requests/other queues, no graceful drain. The livenessProbe restarts gracefully (SIGTERM) and k8s owns backoff.
- The probe runs a full-table `COUNT(*) FILTER … / MAX(checked_at)` over `device_lateongoing_certificate_cycle` (~750k rows) per hit — fine at `periodSeconds: 60`; if it ever shows up in DB load, follow-up is to serve the probe from the 30-min cron's cached result instead of re-querying.
- **Root cause still open:** the underlying ioredis connection leak (ioredis 4.29.1). This PR makes recovery automatic; it does not stop the leak. Separate issue.
- Base is **prod** because the incident is prod and #778's detector only exists on the prod line. `develop` needs the same once prod↔develop are reconciled.

## Test
- `jest late-ongoing-worker-health.spec.ts` → 6 passed.
- `eslint` + `prettier` clean on all changed files.
- (Local full typecheck blocked by pre-existing typeorm-version drift in local node_modules — `FindConditions` in `device.service.ts`, present on clean `origin/prod`; CI compiles against the pinned Rush lockfile.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)